### PR TITLE
[WIP] Improved failure reporting to include the expected/actual result

### DIFF
--- a/app/assets/javascripts/teaspoon-angular.js
+++ b/app/assets/javascripts/teaspoon-angular.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -449,6 +448,10 @@
       el = document.createElement("div");
       el.appendChild(document.createTextNode(str));
       return el.innerHTML;
+    };
+
+    BaseView.prototype.inspect = function(obj) {
+      return JSON.stringify(obj);
     };
 
     return BaseView;
@@ -716,16 +719,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +757,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +779,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -921,7 +920,16 @@
       _ref = this.spec.errors();
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         error = _ref[_i];
-        html += "<div><strong>" + (this.htmlSafe(error.message)) + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
+        html += "<div>";
+        html += "<strong>" + (this.htmlSafe(error.message)) + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable"));
+        html += "</div>";
       }
       return this.el.innerHTML = html;
     };
@@ -1091,6 +1099,8 @@
           skipped: result.skipped,
           link: this.spec.fullDescription,
           message: error.message,
+          expected: error.hasOwnProperty('expected') ? error.expected : void 0,
+          actual: error.hasOwnProperty('actual') ? error.expected : void 0,
           trace: error.stack || error.message || "Stack Trace Unavailable"
         }));
       }
@@ -1134,18 +1144,23 @@
     }
 
     Console.prototype.bindScenarioOutput = function(context, runner, model) {
-      var _this = this;
-      model.on("runnerBegin", function() {
-        return _this.reportRunnerStarting({
-          total: angular.scenario.Describe.specId
-        });
-      });
-      model.on("specEnd", function(spec) {
-        return _this.reportSpecResults(spec);
-      });
-      return model.on("runnerEnd", function() {
-        return _this.reportRunnerResults();
-      });
+      model.on("runnerBegin", (function(_this) {
+        return function() {
+          return _this.reportRunnerStarting({
+            total: angular.scenario.Describe.specId
+          });
+        };
+      })(this));
+      model.on("specEnd", (function(_this) {
+        return function(spec) {
+          return _this.reportSpecResults(spec);
+        };
+      })(this));
+      return model.on("runnerEnd", (function(_this) {
+        return function() {
+          return _this.reportRunnerResults();
+        };
+      })(this));
     };
 
     return Console;
@@ -1168,27 +1183,32 @@
     }
 
     HTML.prototype.bindScenarioOutput = function(context, runner, model) {
-      var _this = this;
-      model.on("specEnd", function(spec) {
-        return _this.reportSpecResults(spec);
-      });
-      model.on("runnerEnd", function() {
-        return _this.reportRunnerResults();
-      });
-      return model.on("runnerBegin", function() {
-        var header, specs;
-        _this.reportRunnerStarting({
-          total: angular.scenario.Describe.specId
-        });
-        header = document.getElementById("header");
-        if (header) {
-          header.parentNode.removeChild(header);
-        }
-        specs = document.getElementById("specs");
-        if (specs) {
-          return specs.style.paddingTop = 0;
-        }
-      });
+      model.on("specEnd", (function(_this) {
+        return function(spec) {
+          return _this.reportSpecResults(spec);
+        };
+      })(this));
+      model.on("runnerEnd", (function(_this) {
+        return function() {
+          return _this.reportRunnerResults();
+        };
+      })(this));
+      return model.on("runnerBegin", (function(_this) {
+        return function() {
+          var header, specs;
+          _this.reportRunnerStarting({
+            total: angular.scenario.Describe.specId
+          });
+          header = document.getElementById("header");
+          if (header) {
+            header.parentNode.removeChild(header);
+          }
+          specs = document.getElementById("specs");
+          if (specs) {
+            return specs.style.paddingTop = 0;
+          }
+        };
+      })(this));
     };
 
     HTML.prototype.envInfo = function() {
@@ -1201,8 +1221,7 @@
 
 }).call(this);
 (function() {
-  var _ref,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   if (!(typeof angular !== "undefined" && angular !== null ? angular.scenario : void 0)) {
@@ -1213,8 +1232,7 @@
     __extends(Runner, _super);
 
     function Runner() {
-      _ref = Runner.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return Runner.__super__.constructor.apply(this, arguments);
     }
 
     Runner.prototype.setup = function() {
@@ -1245,14 +1263,14 @@
     };
 
     Spec.prototype.errors = function() {
-      var step, _i, _len, _ref1, _results;
+      var step, _i, _len, _ref, _results;
       if (!this.spec.steps) {
         return [];
       }
-      _ref1 = this.spec.steps;
+      _ref = this.spec.steps;
       _results = [];
-      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-        step = _ref1[_i];
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        step = _ref[_i];
         if (step.status === "success") {
           continue;
         }

--- a/app/assets/javascripts/teaspoon-jasmine.js
+++ b/app/assets/javascripts/teaspoon-jasmine.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -449,6 +448,10 @@
       el = document.createElement("div");
       el.appendChild(document.createTextNode(str));
       return el.innerHTML;
+    };
+
+    BaseView.prototype.inspect = function(obj) {
+      return JSON.stringify(obj);
     };
 
     return BaseView;
@@ -716,16 +719,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +757,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +779,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -921,7 +920,16 @@
       _ref = this.spec.errors();
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         error = _ref[_i];
-        html += "<div><strong>" + (this.htmlSafe(error.message)) + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
+        html += "<div>";
+        html += "<strong>" + (this.htmlSafe(error.message)) + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable"));
+        html += "</div>";
       }
       return this.el.innerHTML = html;
     };
@@ -1091,6 +1099,8 @@
           skipped: result.skipped,
           link: this.spec.fullDescription,
           message: error.message,
+          expected: error.hasOwnProperty('expected') ? error.expected : void 0,
+          actual: error.hasOwnProperty('actual') ? error.expected : void 0,
           trace: error.stack || error.message || "Stack Trace Unavailable"
         }));
       }
@@ -1120,16 +1130,14 @@
 
 }).call(this);
 (function() {
-  var _ref,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML = (function(_super) {
     __extends(HTML, _super);
 
     function HTML() {
-      _ref = HTML.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return HTML.__super__.constructor.apply(this, arguments);
     }
 
     HTML.prototype.readConfig = function() {
@@ -1150,7 +1158,7 @@
 
 }).call(this);
 (function() {
-  var env, _ref,
+  var env,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1278,54 +1286,63 @@
     __extends(fixture, _super);
 
     function fixture() {
-      _ref = fixture.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return fixture.__super__.constructor.apply(this, arguments);
     }
 
     window.fixture = fixture;
 
     fixture.load = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (!(env.currentSuite || env.currentSpec)) {
         throw "Teaspoon can't load fixtures outside of describe.";
       }
       if (env.currentSuite) {
-        env.beforeEach(function() {
-          return fixture.__super__.constructor.load.apply(_this, args);
-        });
-        env.afterEach(function() {
-          return _this.cleanup();
-        });
+        env.beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.load.apply(_this, args);
+          };
+        })(this));
+        env.afterEach((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.load.apply(this, arguments);
       } else {
-        env.currentSpec.after(function() {
-          return _this.cleanup();
-        });
+        env.currentSpec.after((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.load.apply(this, arguments);
       }
     };
 
     fixture.set = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (!(env.currentSuite || env.currentSpec)) {
         throw "Teaspoon can't load fixtures outside of describe.";
       }
       if (env.currentSuite) {
-        env.beforeEach(function() {
-          return fixture.__super__.constructor.set.apply(_this, args);
-        });
-        env.afterEach(function() {
-          return _this.cleanup();
-        });
+        env.beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.set.apply(_this, args);
+          };
+        })(this));
+        env.afterEach((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.set.apply(this, arguments);
       } else {
-        env.currentSpec.after(function() {
-          return _this.cleanup();
-        });
+        env.currentSpec.after((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.set.apply(this, arguments);
       }
     };

--- a/app/assets/javascripts/teaspoon-mocha.js
+++ b/app/assets/javascripts/teaspoon-mocha.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -449,6 +448,10 @@
       el = document.createElement("div");
       el.appendChild(document.createTextNode(str));
       return el.innerHTML;
+    };
+
+    BaseView.prototype.inspect = function(obj) {
+      return JSON.stringify(obj);
     };
 
     return BaseView;
@@ -716,16 +719,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +757,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +779,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -921,7 +920,16 @@
       _ref = this.spec.errors();
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         error = _ref[_i];
-        html += "<div><strong>" + (this.htmlSafe(error.message)) + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
+        html += "<div>";
+        html += "<strong>" + (this.htmlSafe(error.message)) + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable"));
+        html += "</div>";
       }
       return this.el.innerHTML = html;
     };
@@ -1091,6 +1099,8 @@
           skipped: result.skipped,
           link: this.spec.fullDescription,
           message: error.message,
+          expected: error.hasOwnProperty('expected') ? error.expected : void 0,
+          actual: error.hasOwnProperty('actual') ? error.expected : void 0,
           trace: error.stack || error.message || "Stack Trace Unavailable"
         }));
       }
@@ -1153,8 +1163,7 @@
 
 }).call(this);
 (function() {
-  var _ref,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1194,8 +1203,7 @@
     __extends(SpecView, _super);
 
     function SpecView() {
-      _ref = SpecView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return SpecView.__super__.constructor.apply(this, arguments);
     }
 
     SpecView.prototype.updateState = function(state) {
@@ -1208,7 +1216,7 @@
 
 }).call(this);
 (function() {
-  var env, _ref,
+  var env,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1312,35 +1320,36 @@
     __extends(fixture, _super);
 
     function fixture() {
-      _ref = fixture.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return fixture.__super__.constructor.apply(this, arguments);
     }
 
     window.fixture = fixture;
 
     fixture.load = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (env.started) {
         return fixture.__super__.constructor.load.apply(this, arguments);
       } else {
-        return beforeEach(function() {
-          return fixture.__super__.constructor.load.apply(_this, args);
-        });
+        return beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.load.apply(_this, args);
+          };
+        })(this));
       }
     };
 
     fixture.set = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (env.started) {
         return fixture.__super__.constructor.set.apply(this, arguments);
       } else {
-        return beforeEach(function() {
-          return fixture.__super__.constructor.set.apply(_this, args);
-        });
+        return beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.set.apply(_this, args);
+          };
+        })(this));
       }
     };
 

--- a/app/assets/javascripts/teaspoon-qunit.js
+++ b/app/assets/javascripts/teaspoon-qunit.js
@@ -1237,7 +1237,14 @@
       _ref = this.spec.errors();
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         error = _ref[_i];
-        html += "<strong>" + error.message + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "<br/>";
+        html += "<strong>" + error.message + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "<br/>";
       }
       div.innerHTML = html;
       return this.append(div);

--- a/app/assets/javascripts/teaspoon-qunit.js
+++ b/app/assets/javascripts/teaspoon-qunit.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -449,6 +448,10 @@
       el = document.createElement("div");
       el.appendChild(document.createTextNode(str));
       return el.innerHTML;
+    };
+
+    BaseView.prototype.inspect = function(obj) {
+      return JSON.stringify(obj);
     };
 
     return BaseView;
@@ -716,16 +719,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +757,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +779,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -921,7 +920,16 @@
       _ref = this.spec.errors();
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         error = _ref[_i];
-        html += "<div><strong>" + (this.htmlSafe(error.message)) + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
+        html += "<div>";
+        html += "<strong>" + (this.htmlSafe(error.message)) + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable"));
+        html += "</div>";
       }
       return this.el.innerHTML = html;
     };
@@ -1091,6 +1099,8 @@
           skipped: result.skipped,
           link: this.spec.fullDescription,
           message: error.message,
+          expected: error.hasOwnProperty('expected') ? error.expected : void 0,
+          actual: error.hasOwnProperty('actual') ? error.expected : void 0,
           trace: error.stack || error.message || "Stack Trace Unavailable"
         }));
       }
@@ -1161,8 +1171,7 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1218,17 +1227,16 @@
     __extends(SpecView, _super);
 
     function SpecView() {
-      _ref = SpecView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return SpecView.__super__.constructor.apply(this, arguments);
     }
 
     SpecView.prototype.buildErrors = function() {
-      var div, error, html, _i, _len, _ref1;
+      var div, error, html, _i, _len, _ref;
       div = this.createEl("div");
       html = "";
-      _ref1 = this.spec.errors();
-      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-        error = _ref1[_i];
+      _ref = this.spec.errors();
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        error = _ref[_i];
         html += "<strong>" + error.message + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "<br/>";
       }
       div.innerHTML = html;
@@ -1257,18 +1265,26 @@
     __extends(FailureView, _super);
 
     function FailureView() {
-      _ref1 = FailureView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return FailureView.__super__.constructor.apply(this, arguments);
     }
 
     FailureView.prototype.build = function() {
-      var error, html, _i, _len, _ref2;
+      var error, html, _i, _len, _ref;
       FailureView.__super__.build.call(this, "spec");
       html = "<h1 class=\"teaspoon-clearfix\"><a href=\"" + this.spec.link + "\">" + (this.htmlSafe(this.spec.fullDescription)) + "</a></h1>";
-      _ref2 = this.spec.errors();
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        error = _ref2[_i];
-        html += "<div><strong>" + error.message + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
+      _ref = this.spec.errors();
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        error = _ref[_i];
+        html += "<div>";
+        html += "<strong>" + error.message + "</strong><br/>";
+        if (error.hasOwnProperty('expected')) {
+          html += "<strong>Expected:</strong> <code>" + (this.inspect(error.expected)) + "</code><br/>";
+        }
+        if (error.hasOwnProperty('actual')) {
+          html += "<strong>Actual:</strong> <code>" + (this.inspect(error.actual)) + "</code><br/>";
+        }
+        html += "" + (this.htmlSafe(error.stack || "Stack trace unavailable"));
+        html += "</div>";
       }
       return this.el.innerHTML = html;
     };
@@ -1345,7 +1361,9 @@
           continue;
         }
         _results.push({
-          message: item.message,
+          message: item.message || 'No message given.',
+          expected: item.expected,
+          actual: item.actual,
           stack: item.source
         });
       }

--- a/app/assets/javascripts/teaspoon-qunit.js
+++ b/app/assets/javascripts/teaspoon-qunit.js
@@ -1349,7 +1349,7 @@
     }
 
     Spec.prototype.errors = function() {
-      var item, _i, _len, _ref, _results;
+      var error, item, _i, _len, _ref, _results;
       if (!this.spec.failed) {
         return [];
       }
@@ -1360,12 +1360,17 @@
         if (item.result) {
           continue;
         }
-        _results.push({
+        error = {
           message: item.message || 'No message given.',
-          expected: item.expected,
-          actual: item.actual,
           stack: item.source
-        });
+        };
+        if (item.hasOwnProperty('expected')) {
+          error.expected = item.expected;
+        }
+        if (item.hasOwnProperty('actual')) {
+          error.actual = item.actual;
+        }
+        _results.push(error);
       }
       return _results;
     };

--- a/app/assets/javascripts/teaspoon/base/reporters/console.coffee
+++ b/app/assets/javascripts/teaspoon/base/reporters/console.coffee
@@ -53,14 +53,16 @@ class Teaspoon.Reporters.Console
     result = @spec.result()
     for error in @spec.errors()
       @log
-        type:    "spec"
-        suite:   @spec.suiteName
-        label:   @spec.description
-        status:  result.status
-        skipped: result.skipped
-        link:    @spec.fullDescription
-        message: error.message
-        trace:   error.stack || error.message || "Stack Trace Unavailable"
+        type:     "spec"
+        suite:    @spec.suiteName
+        label:    @spec.description
+        status:   result.status
+        skipped:  result.skipped
+        link:     @spec.fullDescription
+        message:  error.message
+        expected: error.expected if error.hasOwnProperty('expected')
+        actual:   error.expected if error.hasOwnProperty('actual')
+        trace:    error.stack || error.message || "Stack Trace Unavailable"
 
 
   reportRunnerResults: =>

--- a/app/assets/javascripts/teaspoon/base/reporters/html/base_view.coffee
+++ b/app/assets/javascripts/teaspoon/base/reporters/html/base_view.coffee
@@ -47,3 +47,6 @@ class Teaspoon.Reporters.BaseView
     el = document.createElement("div")
     el.appendChild(document.createTextNode(str))
     el.innerHTML
+
+  inspect: (obj) ->
+    JSON.stringify(obj)

--- a/app/assets/javascripts/teaspoon/base/reporters/html/failure_view.coffee
+++ b/app/assets/javascripts/teaspoon/base/reporters/html/failure_view.coffee
@@ -8,5 +8,10 @@ class Teaspoon.Reporters.HTML.FailureView extends Teaspoon.Reporters.BaseView
     super("spec")
     html = """<h1 class="teaspoon-clearfix"><a href="#{@spec.link}">#{@htmlSafe(@spec.fullDescription)}</a></h1>"""
     for error in @spec.errors()
-      html += """<div><strong>#{@htmlSafe(error.message)}</strong><br/>#{@htmlSafe(error.stack || "Stack trace unavailable")}</div>"""
+      html += """<div>"""
+      html += """<strong>#{@htmlSafe(error.message)}</strong><br/>"""
+      html += """<strong>Expected:</strong> <code>#{@inspect(error.expected)}</code><br/>""" if error.hasOwnProperty('expected')
+      html += """<strong>Actual:</strong> <code>#{@inspect(error.actual)}</code><br/>""" if error.hasOwnProperty('actual')
+      html += """#{@htmlSafe(error.stack || "Stack trace unavailable")}"""
+      html += """</div>"""
     @el.innerHTML = html

--- a/app/assets/javascripts/teaspoon/qunit.coffee
+++ b/app/assets/javascripts/teaspoon/qunit.coffee
@@ -33,7 +33,12 @@ class Teaspoon.Spec
     return [] unless @spec.failed
     for item in @spec.assertions
       continue if item.result
-      {message: item.message, stack: item.source}
+      {
+        message: item.message || 'No message given.',
+        expected: item.expected,
+        actual: item.actual,
+        stack: item.source
+      }
 
 
   getParents: ->

--- a/app/assets/javascripts/teaspoon/qunit.coffee
+++ b/app/assets/javascripts/teaspoon/qunit.coffee
@@ -33,13 +33,18 @@ class Teaspoon.Spec
     return [] unless @spec.failed
     for item in @spec.assertions
       continue if item.result
-      {
-        message: item.message || 'No message given.',
-        expected: item.expected,
-        actual: item.actual,
-        stack: item.source
-      }
 
+      error =
+        message: item.message || 'No message given.'
+        stack: item.source
+
+      if item.hasOwnProperty('expected')
+        error.expected = item.expected
+
+      if item.hasOwnProperty('actual')
+        error.actual = item.actual
+
+      error
 
   getParents: ->
     return [] unless @parent

--- a/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
+++ b/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
@@ -67,7 +67,12 @@ class Teaspoon.Reporters.HTML.FailureView extends Teaspoon.Reporters.HTML.Failur
     super("spec")
     html = """<h1 class="teaspoon-clearfix"><a href="#{@spec.link}">#{@htmlSafe(@spec.fullDescription)}</a></h1>"""
     for error in @spec.errors()
-      html += """<div><strong>#{error.message}</strong><br/>#{@htmlSafe(error.stack || "Stack trace unavailable")}</div>"""
+      html += """<div>"""
+      html += """<strong>#{error.message}</strong><br/>"""
+      html += """<strong>Expected:</strong> <code>#{@inspect(error.expected)}</code><br/>""" if error.hasOwnProperty('expected')
+      html += """<strong>Actual:</strong> <code>#{@inspect(error.actual)}</code><br/>""" if error.hasOwnProperty('actual')
+      html += """#{@htmlSafe(error.stack || "Stack trace unavailable")}"""
+      html += """</div>"""
     @el.innerHTML = html
 
 

--- a/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
+++ b/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
@@ -45,7 +45,10 @@ class Teaspoon.Reporters.HTML.SpecView extends Teaspoon.Reporters.HTML.SpecView
     div = @createEl("div")
     html = ""
     for error in @spec.errors()
-      html += """<strong>#{error.message}</strong><br/>#{@htmlSafe(error.stack || "Stack trace unavailable")}<br/>"""
+      html += """<strong>#{error.message}</strong><br/>"""
+      html += """<strong>Expected:</strong> <code>#{@inspect(error.expected)}</code><br/>""" if error.hasOwnProperty('expected')
+      html += """<strong>Actual:</strong> <code>#{@inspect(error.actual)}</code><br/>""" if error.hasOwnProperty('actual')
+      html += """#{@htmlSafe(error.stack || "Stack trace unavailable")}<br/>"""
     div.innerHTML = html
     @append(div)
 


### PR DESCRIPTION
If available, the reporters would now include the `expected` and `actual` result for each failed assertion. Currently, this is only supported by the qunit adapter.

Fixes #225

* * *

The qunit assertion API looks like this: `equal(actual, expected[, message]);`. When this fails, it'll pass `{actual: actual, expected: expected, message: message, source: <stack trace>, ...}` to the reporter. Most people don't bother putting a message in assertions like these, which is why it is often just reported as `undefined` in the teaspoon reporter.

I bumped into this issue when setting up teaspoon for our app, so I forked it and fixed it on a branch. This is how it looks like:

![teaspoon with expected/actual](https://dl.dropboxusercontent.com/s/gs6blneiib9b3o3/Screenshot%202014-05-22%2020.40.47.png)

I just need to work for our app, I suppose there are other things to consider before this can be accepted (code style, look/feel, tests, changelog, etc), and I'm not sure if I'll have time to do those in the near term. If someone has the time to pick this up, please feel free to use my commit as a starting point. Would love to see this merged into master.

References:
* https://github.com/modeset/teaspoon/blob/master/vendor/assets/javascripts/qunit/1.12.0.js#L922-L927
* https://github.com/modeset/teaspoon/blob/master/vendor/assets/javascripts/qunit/1.14.0.js#L436-L441

cc @cwick @jejacks0n