### PR TITLE
Prevent early exit after an error

### DIFF
--- a/lib/teaspoon/drivers/phantomjs/runner.js
+++ b/lib/teaspoon/drivers/phantomjs/runner.js
@@ -77,7 +77,7 @@
           if (_this.errored) {
             _this.errorTimeout = setTimeout((function() {
               return _this.fail("Javascript error has cause a timeout.");
-            }), 1000);
+            }), _this.timeout);
             return _this.errored = false;
           }
         },


### PR DESCRIPTION
Use the provided timeout to give the runtime longer before quitting after an error.

This fixes a problem where we were seeing a non-fatal parse error prevent our test suite from running.

The error sets a one second timer, during which time, if there are no calls to `console.log`, then a fatal error is assumed. Making this timeout tunable gives us some leeway in troubleshooting.