### PR TITLE
Ignore phantomjs "Operation canceled" error message that happens on mult...

### DIFF
--- a/lib/teaspoon/drivers/phantomjs/runner.js
+++ b/lib/teaspoon/drivers/phantomjs/runner.js
@@ -88,7 +88,7 @@
           var defined = _this.page.evaluate(function() {
             return window.Teaspoon;
           });
-          if (!(status === "success" && defined)) {
+          if (! defined) {
             _this.fail("Failed to load: " + _this.url);
             return;
           }

--- a/spec/javascripts/teaspoon/phantomjs/runner_spec.coffee
+++ b/spec/javascripts/teaspoon/phantomjs/runner_spec.coffee
@@ -146,10 +146,19 @@ describe "PhantomJS Runner", ->
         @runner.initPage()
         @waitSpy = spyOn(@runner, "waitForResults")
 
-      it "fails if the status was not success", ->
+      it "does not fail if status was not success and teaspoon was loaded", ->
         spy = spyOn(@runner, "fail")
         evalSpy = spyOn(@runner.page, "evaluate").andReturn(true)
         @callbacks.onLoadFinished("failure")
+        expect(spy).not.toHaveBeenCalledWith("Failed to load: #{@runner.url}")
+        expect(evalSpy).toHaveBeenCalled()
+        expect(@waitSpy).wasCalled()
+
+
+      it "fails if teaspoon was not loaded", ->
+        spy = spyOn(@runner, "fail")
+        evalSpy = spyOn(@runner.page, "evaluate").andReturn(undefined)
+        @callbacks.onLoadFinished("success")
         expect(spy).toHaveBeenCalledWith("Failed to load: #{@runner.url}")
         expect(evalSpy).toHaveBeenCalled()
         expect(@waitSpy).wasNotCalled()


### PR DESCRIPTION
...iple page loads (ajax requests).

The issue I am experiencing right now is related to phantomjs throwing 'Operation canceled' on too many ajax requests on a single page load. This happens when test suite is large enough and there are seriously quite a lot of ajax requests being performed in it.

And it just so happens that `onLoadFinished` is invoked with status `fail` while `window.Teaspoon` is defined and test cases can be run correctly. I would like to exclude phantomjs' status as criteria of failure because it seems unreliable and `window.Teaspoon` is enough. 

P.S. Someone did research on how many requests is allowed https://groups.google.com/forum/#!topic/phantomjs/Tg-Jq-cmuVo
