### PR TITLE
README: Provide an example of how to pass `driver_options` to the teaspoon rake task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The rake task provides several ways of focusing tests. You can specify the suite
 ```
 rake teaspoon suite=my_fantastic_suite
 rake teaspoon files=spec/javascripts/integration,spec/javascripts/calculator_spec.js
+rake teaspoon driver_options="—ssl-protocol=TLSv1 --ignore-ssl-errors=yes"
 ```
 
 ### CLI


### PR DESCRIPTION
This additional readme example may be useful to future developers. I assumed the `driver_options` rake argument was meant to be uppercase as described in the [command line documentation](https://github.com/modeset/teaspoon#console-runner-specific).

The documentation states use "--driver-options" or "DRIVER_OPTIONS=". When running rake with "--driver-options" I get the output:

    invalid option: --driver_options=--ignore-ssl-errors=yes --ssl-protocol=TLSv1

So I assumed the ENV syntax was correct instead. When using an ENV argument no error is reported, leading me to believe this was working. Only after looking at [teaspoon.rake](https://github.com/modeset/teaspoon/blob/master/lib/tasks/teaspoon.rake) did I see the task only accepts 4 options, one of them being a lowercase "driver_options".