### PR TITLE
Switching instrument_file? to be in Instrumentation class

### DIFF
--- a/app/views/teaspoon/suite/_boot_require_js.html.erb
+++ b/app/views/teaspoon/suite/_boot_require_js.html.erb
@@ -3,11 +3,9 @@ rails_config = Rails.application.config
 require_options = {baseUrl: rails_config.assets.prefix}
 require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
 specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
-
-specs.each {|s| require_options['shim'][s] = [@suite.helper] }
 %>
 
-<%= javascript_include_tag 'require' %>
+<%= javascript_include_tag @suite.helper %>
 <script type="text/javascript">
   Teaspoon.onWindowLoad(function () {
     // setup the Teaspoon path prefix to load /assets

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -14,7 +14,20 @@ module Teaspoon
       env["QUERY_STRING"].to_s =~ /instrument=(1|true)/ &&            # the instrument param was provided
       response[0] == 200 &&                                           # the status is 200 (304 might be needed here too)
       response[1]["Content-Type"].to_s == "application/javascript" && # the format is something that we care about
-      response[2].respond_to?(:source)                                # it looks like an asset
+      response[2].respond_to?(:source) &&                             # it looks like an asset
+      instrument_file?(response[2].pathname.to_s)
+    end
+
+    def self.instrument_file?(file)
+      no_coverage = Teaspoon.configuration.suite_configs['default'][:instance].no_coverage
+      for ignored in no_coverage
+        if ignored.is_a?(String)
+          return false if File.basename(file) == ignored
+        elsif ignored.is_a?(Regexp)
+          return false if file =~ ignored
+        end
+      end
+      true
     end
 
     def self.executable

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -73,13 +73,6 @@ module Teaspoon
     def instrument_file?(file)
       return false unless @options[:coverage] || Teaspoon.configuration.use_coverage
       return false if include_spec?(file)
-      for ignored in no_coverage
-        if ignored.is_a?(String)
-          return false if File.basename(file) == ignored
-        elsif ignored.is_a?(Regexp)
-          return false if file =~ ignored
-        end
-      end
       true
     end
 

--- a/spec/teaspoon/suite_spec.rb
+++ b/spec/teaspoon/suite_spec.rb
@@ -88,7 +88,7 @@ describe Teaspoon::Suite do
     it "returns the asset tree (all dependencies resolved) if we want coverage" do
       subject.instance_variable_set(:@options, coverage: true)
       result = subject.spec_assets(true)
-      expect(result).to include("support/json2.js?body=1")
+      expect(result).to include("support/json2.js?body=1&instrument=1")
       expect(result).to include("spec_helper.js?body=1")
       expect(result).to include("drivers/phantomjs/runner.js?body=1&instrument=1")
     end


### PR DESCRIPTION
This was done to solve the RequireJS issue (https://github.com/modeset/teaspoon/pull/240), would like to hear your thoughts about this.  Some things:

* The reason why this change works with RequireJS is because the decision to instrument is now made in the Sprockets hook, and all RequireJS requests go through Sprockets.
* I wasn't sure how to grab the current config so I grabbed the default config with `Teaspoon.configuration.suite_configs['default'][:instance]`.  I can help write specs once this part is figured out.
* I was thinking about completely forgoing the addition of `instrument=1`, but wasn't sure which way to go.  Either way works with RequireJS, as you can add a `instrument=1` to the end of every RequireJS request through the `urlArgs` config.