### PR TITLE
Add missing exception UnknownCoverage

### DIFF
--- a/lib/teaspoon/exceptions.rb
+++ b/lib/teaspoon/exceptions.rb
@@ -6,6 +6,7 @@ module Teaspoon
   class RunnerException < Teaspoon::Error; end
   class ExporterException < Teaspoon::Error; end
   class UnknownFramework < Teaspoon::Error; end
+  class UnknownCoverage < Teaspoon::Error; end
   class UnknownDriver < Teaspoon::Error; end
   class UnknownDriverOptions < Teaspoon::Error; end
   class UnknownFormatter < Teaspoon::Error; end


### PR DESCRIPTION
Exception was raised at https://github.com/modeset/teaspoon/blob/master/lib/teaspoon/coverage.rb#L37 but was not defined anywhere.

Addresses #267