### PR TITLE
Add configuration which allows you to disable expansion of assets

### DIFF
--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -71,13 +71,15 @@ module Teaspoon
       attr_accessor   :matcher, :helper, :javascripts, :stylesheets,
                       :boot_partial, :body_partial,
                       :no_coverage,
-                      :hooks
+                      :hooks,
+                      :expand_assets
 
       def initialize
         @matcher      = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
         @helper       = "spec_helper"
         @javascripts  = ["jasmine/1.3.1", "teaspoon-jasmine"]
         @stylesheets  = ["teaspoon"]
+        @expand_assets= true
 
         @boot_partial = "boot"
         @body_partial = "body"

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -56,7 +56,7 @@ module Teaspoon
     def asset_tree(sources)
       sources.collect do |source|
         asset = @env.find_asset(source)
-        if asset && asset.respond_to?(:logical_path)
+        if asset && asset.respond_to?(:logical_path) && config.expand_assets
           asset.to_a.map { |a| asset_url(a) }
         else
           source unless source.blank?


### PR DESCRIPTION
This adds a configuration variable so that you can disable expansion of assets.  This fixes issue:

https://github.com/modeset/teaspoon/issues/292

By allowing you to configure and turn off asset expansion.