### PR TITLE
Add instrumentation for RequireJS

### DIFF
--- a/app/views/teaspoon/suite/_boot_require_js.html.erb
+++ b/app/views/teaspoon/suite/_boot_require_js.html.erb
@@ -1,6 +1,7 @@
 <%
 rails_config = Rails.application.config
 require_options = {baseUrl: rails_config.assets.prefix}
+require_options.merge!(urlArgs: "instrument=1", waitSeconds: 0) if Teaspoon.configuration.use_coverage
 require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
 specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
 %>


### PR DESCRIPTION
Uses urlArgs to include `instrument=1` to urls when coverage is required.
See: http://requirejs.org/docs/api.html#config-urlArgs

Added `waitSeconds: 0` as on my Project I was getting timeouts when it
was attempting to add instrumentation to all my files.

*NB:* I created this in a local version of Teaspoon which was using version `0.8.0`, the output showed all the files and I was able to use the html report to view the files. I have just tried this on `master` and it does not seem to load any files. Is there something thats changed between `0.8.0` and `master` that requires different config?