### PR TITLE
[WIP] Ignored instrumentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,13 +360,11 @@ end
 
 Teaspoon allows defining files and directories to ignore when performing coverage instrumentation.
 
-The below example will ensure that the files within `/test/javascripts` and `/vendor/assets` are not intrumented by Istanbul and will not show up in the coverage results.
+The below example will ensure that any files within `/test/javascripts` and `/vendor/assets` are not intrumented by Istanbul and will not show up in the coverage results.
 
 ```ruby
-config.coverage_ignored = ["/test/javascripts", "/vendor/assets"]
+config.coverage_ignored = ["/test/javascripts", %r{/vendor/assets}]
 ```
-
-The defined strings are used within regular expression and any filepath which matches any of these will not be instrumented.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Teaspoon allows defining files and directories to ignore when performing coverag
 The below example will ensure that the files within `/test/javascripts` and `/vendor/assets` are not intrumented by Istanbul and will not show up in the coverage results.
 
 ```ruby
-config.coverage_ignored_files = ["/test/javascripts", "/vendor/assets"]
+config.coverage_ignored = ["/test/javascripts", "/vendor/assets"]
 ```
 
 The defined strings are used within regular expression and any filepath which matches any of these will not be instrumented.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,17 @@ config.coverage :CI do |coverage|
 end
 ```
 
+### Ignoring Files
+
+Teaspoon allows defining files and directories to ignore when performing coverage instrumentation.
+
+The below example will ensure that the files within `/test/javascripts` and `/vendor/assets` are not intrumented by Istanbul and will not show up in the coverage results.
+
+```ruby
+config.coverage_ignored_files = ["/test/javascripts", "/vendor/assets"]
+```
+
+The defined strings are used within regular expression and any filepath which matches any of these will not be instrumented.
 
 ## Configuration
 

--- a/lib/generators/teaspoon/install/templates/jasmine/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/jasmine/env_comments.rb.tt
@@ -164,6 +164,9 @@ Teaspoon.configure do |config|
   # Specify that you always want a coverage configuration to be used.
   #config.use_coverage = nil
 
+  # Specify any files/directories that should not be instrumented
+  #config.coverage_ignored_files = ["test/javascripts"]
+
   config.coverage do |coverage|
 
     # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.

--- a/lib/generators/teaspoon/install/templates/jasmine/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/jasmine/env_comments.rb.tt
@@ -165,7 +165,7 @@ Teaspoon.configure do |config|
   #config.use_coverage = nil
 
   # Specify any files/directories that should not be instrumented
-  #config.coverage_ignored_files = ["test/javascripts"]
+  #config.coverage_ignored = ["test/javascripts"]
 
   config.coverage do |coverage|
 

--- a/lib/generators/teaspoon/install/templates/mocha/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/mocha/env_comments.rb.tt
@@ -164,6 +164,9 @@ Teaspoon.configure do |config|
   # Specify that you always want a coverage configuration to be used.
   #config.use_coverage = nil
 
+  # Specify any files/directories that should not be instrumented
+  #config.coverage_ignored_files = ["test/javascripts"]
+
   config.coverage do |coverage|
 
     # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.

--- a/lib/generators/teaspoon/install/templates/mocha/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/mocha/env_comments.rb.tt
@@ -165,7 +165,7 @@ Teaspoon.configure do |config|
   #config.use_coverage = nil
 
   # Specify any files/directories that should not be instrumented
-  #config.coverage_ignored_files = ["test/javascripts"]
+  #config.coverage_ignored = ["test/javascripts"]
 
   config.coverage do |coverage|
 

--- a/lib/generators/teaspoon/install/templates/qunit/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/qunit/env_comments.rb.tt
@@ -164,6 +164,9 @@ Teaspoon.configure do |config|
   # Specify that you always want a coverage configuration to be used.
   #config.use_coverage = nil
 
+  # Specify any files/directories that should not be instrumented
+  #config.coverage_ignored_files = ["test/javascripts"]
+
   config.coverage do |coverage|
 
     # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.

--- a/lib/generators/teaspoon/install/templates/qunit/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/qunit/env_comments.rb.tt
@@ -165,7 +165,7 @@ Teaspoon.configure do |config|
   #config.use_coverage = nil
 
   # Specify any files/directories that should not be instrumented
-  #config.coverage_ignored_files = ["test/javascripts"]
+  #config.coverage_ignored = ["test/javascripts"]
 
   config.coverage do |coverage|
 

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -26,21 +26,21 @@ module Teaspoon
 
     cattr_accessor :driver, :driver_options, :driver_timeout, :server, :server_port, :server_timeout, :fail_fast,
                    :formatters, :color, :suppress_log,
-                   :use_coverage, :coverage_ignored_files
-    @@driver                 = "phantomjs"
-    @@driver_options         = nil
-    @@driver_timeout         = 180
-    @@server                 = nil
-    @@server_port            = nil
-    @@server_timeout         = 20
-    @@fail_fast              = true
+                   :use_coverage, :coverage_ignored
+    @@driver           = "phantomjs"
+    @@driver_options   = nil
+    @@driver_timeout   = 180
+    @@server           = nil
+    @@server_port      = nil
+    @@server_timeout   = 20
+    @@fail_fast        = true
 
-    @@formatters             = ["dot"]
-    @@color                  = true
-    @@suppress_log           = false
+    @@formatters       = ["dot"]
+    @@color            = true
+    @@suppress_log     = false
 
-    @@use_coverage           = nil
-    @@coverage_ignored_files = []
+    @@use_coverage     = nil
+    @@coverage_ignored = []
 
     # options that can be specified in the ENV
 
@@ -153,10 +153,10 @@ module Teaspoon
       @@formatters.to_s.split(/,\s?/)
     end
 
-    def self.coverage_ignored_files
-      return [] if @@coverage_ignored_files.blank?
-      return @@coverage_ignored_files if @@coverage_ignored_files.is_a?(Array)
-      @@coverage_ignored_files.to_s.split(/,\s?/)
+    def self.coverage_ignored
+      return [] if @@coverage_ignored.blank?
+      return @@coverage_ignored if @@coverage_ignored.is_a?(Array)
+      @@coverage_ignored.to_s.split(/,\s?/)
     end
 
     # override from env or options

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -153,12 +153,6 @@ module Teaspoon
       @@formatters.to_s.split(/,\s?/)
     end
 
-    def self.coverage_ignored
-      return [] if @@coverage_ignored.blank?
-      return @@coverage_ignored if @@coverage_ignored.is_a?(Array)
-      @@coverage_ignored.to_s.split(/,\s?/)
-    end
-
     # override from env or options
 
     def self.override_from_options(options)

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -26,20 +26,21 @@ module Teaspoon
 
     cattr_accessor :driver, :driver_options, :driver_timeout, :server, :server_port, :server_timeout, :fail_fast,
                    :formatters, :color, :suppress_log,
-                   :use_coverage
-    @@driver         = "phantomjs"
-    @@driver_options = nil
-    @@driver_timeout = 180
-    @@server         = nil
-    @@server_port    = nil
-    @@server_timeout = 20
-    @@fail_fast      = true
+                   :use_coverage, :coverage_ignored_files
+    @@driver                 = "phantomjs"
+    @@driver_options         = nil
+    @@driver_timeout         = 180
+    @@server                 = nil
+    @@server_port            = nil
+    @@server_timeout         = 20
+    @@fail_fast              = true
 
-    @@formatters     = ["dot"]
-    @@color          = true
-    @@suppress_log   = false
+    @@formatters             = ["dot"]
+    @@color                  = true
+    @@suppress_log           = false
 
-    @@use_coverage   = nil
+    @@use_coverage           = nil
+    @@coverage_ignored_files = []
 
     # options that can be specified in the ENV
 
@@ -150,6 +151,12 @@ module Teaspoon
       return ["dot"] if @@formatters.blank?
       return @@formatters if @@formatters.is_a?(Array)
       @@formatters.to_s.split(/,\s?/)
+    end
+
+    def self.coverage_ignored_files
+      return [] if @@coverage_ignored_files.blank?
+      return @@coverage_ignored_files if @@coverage_ignored_files.is_a?(Array)
+      @@coverage_ignored_files.to_s.split(/,\s?/)
     end
 
     # override from env or options

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -19,9 +19,9 @@ module Teaspoon
     end
 
     def self.ignored?(asset)
-      Teaspoon::Configuration.coverage_ignored_files.select do |file|
+      Teaspoon::Configuration.coverage_ignored_files.any? do |file|
         asset.pathname.to_s.match(file)
-      end.any?
+      end
     end
 
     def self.executable

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -14,7 +14,14 @@ module Teaspoon
         env["QUERY_STRING"].to_s =~ /instrument=(1|true)/ &&            # the instrument param was provided
         response[0] == 200 &&                                           # the status is 200 (304 maybe?)
         response[1]["Content-Type"].to_s == "application/javascript" && # the format is something that we care about
-        response[2].respond_to?(:source)                                # it looks like an asset
+        response[2].respond_to?(:source) &&                             # it looks like an asset
+        !ignored?(response[2])                                          # it should not be ignored
+    end
+
+    def self.ignored?(asset)
+      Teaspoon::Configuration.coverage_ignored_files.select do |file|
+        asset.pathname.to_s.match(file)
+      end.any?
     end
 
     def self.executable

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -19,8 +19,8 @@ module Teaspoon
     end
 
     def self.ignored?(asset)
-      Teaspoon::Configuration.coverage_ignored_files.any? do |file|
-        asset.pathname.to_s.match(file)
+      Teaspoon::Configuration.coverage_ignored.any? do |ignore|
+        asset.pathname.to_s.match(ignore)
       end
     end
 

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -158,9 +158,9 @@ describe Teaspoon::Configuration do
       expect(subject.coverage_ignored).to eq([])
     end
 
-    it "returns the array of Strings defined during configuration" do
-      subject.coverage_ignored = ["/spec/javascripts", "/vendor/assets"]
-      expect(subject.coverage_ignored).to eq(["/spec/javascripts", "/vendor/assets"])
+    it "returns the array defined during configuration" do
+      subject.coverage_ignored = ["/spec/javascripts", %r{/vendor/assets}]
+      expect(subject.coverage_ignored).to eq(["/spec/javascripts", %r{/vendor/assets}])
     end
 
   end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -50,7 +50,7 @@ describe Teaspoon::Configuration do
     @orig_root = subject.root
     @orig_asset_paths = subject.asset_paths
     @orig_formatters = subject.formatters
-    @orig_coverage_ignored_files = subject.coverage_ignored_files
+    @orig_coverage_ignored = subject.coverage_ignored
   end
 
   after do
@@ -60,7 +60,7 @@ describe Teaspoon::Configuration do
     subject.root = @orig_root
     subject.asset_paths = @orig_asset_paths
     subject.formatters = @orig_formatters
-    subject.coverage_ignored_files = @orig_coverage_ignored_files
+    subject.coverage_ignored = @orig_coverage_ignored
   end
 
   it "has the default configuration" do
@@ -81,7 +81,7 @@ describe Teaspoon::Configuration do
     expect(subject.fail_fast).to be_truthy
     expect(subject.suppress_log).to be_falsey
     expect(subject.color).to be_truthy
-    expect(subject.coverage_ignored_files).to eq([])
+    expect(subject.coverage_ignored).to eq([])
 
     expect(subject.suite_configs).to be_a(Hash)
     expect(subject.coverage_configs).to be_a(Hash)
@@ -152,15 +152,15 @@ describe Teaspoon::Configuration do
 
   end
 
-  describe ".coverage_ignored_files" do
+  describe ".coverage_ignored" do
 
     it "returns an empty list if nothing was set" do
-      expect(subject.coverage_ignored_files).to eq([])
+      expect(subject.coverage_ignored).to eq([])
     end
 
     it "returns an array of  if they were comma separated" do
-      subject.coverage_ignored_files = "/spec/javascripts,/vendor/assets"
-      expect(subject.coverage_ignored_files).to eq(["/spec/javascripts", "/vendor/assets"])
+      subject.coverage_ignored = "/spec/javascripts,/vendor/assets"
+      expect(subject.coverage_ignored).to eq(["/spec/javascripts", "/vendor/assets"])
     end
 
   end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -50,6 +50,7 @@ describe Teaspoon::Configuration do
     @orig_root = subject.root
     @orig_asset_paths = subject.asset_paths
     @orig_formatters = subject.formatters
+    @orig_coverage_ignored_files = subject.coverage_ignored_files
   end
 
   after do
@@ -59,6 +60,7 @@ describe Teaspoon::Configuration do
     subject.root = @orig_root
     subject.asset_paths = @orig_asset_paths
     subject.formatters = @orig_formatters
+    subject.coverage_ignored_files = @orig_coverage_ignored_files
   end
 
   it "has the default configuration" do
@@ -79,6 +81,7 @@ describe Teaspoon::Configuration do
     expect(subject.fail_fast).to be_truthy
     expect(subject.suppress_log).to be_falsey
     expect(subject.color).to be_truthy
+    expect(subject.coverage_ignored_files).to eq([])
 
     expect(subject.suite_configs).to be_a(Hash)
     expect(subject.coverage_configs).to be_a(Hash)
@@ -145,6 +148,19 @@ describe Teaspoon::Configuration do
       expect(subject).to receive(:driver=).with("driver")
 
       subject.send(:override_from_env, "FAIL_FAST" => "true", "DRIVER_TIMEOUT" => "123", "DRIVER" => "driver")
+    end
+
+  end
+
+  describe ".coverage_ignored_files" do
+
+    it "returns an empty list if nothing was set" do
+      expect(subject.coverage_ignored_files).to eq([])
+    end
+
+    it "returns an array of  if they were comma separated" do
+      subject.coverage_ignored_files = "/spec/javascripts,/vendor/assets"
+      expect(subject.coverage_ignored_files).to eq(["/spec/javascripts", "/vendor/assets"])
     end
 
   end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -158,8 +158,8 @@ describe Teaspoon::Configuration do
       expect(subject.coverage_ignored).to eq([])
     end
 
-    it "returns an array of  if they were comma separated" do
-      subject.coverage_ignored = "/spec/javascripts,/vendor/assets"
+    it "returns the array of Strings defined during configuration" do
+      subject.coverage_ignored = ["/spec/javascripts", "/vendor/assets"]
       expect(subject.coverage_ignored).to eq(["/spec/javascripts", "/vendor/assets"])
     end
 

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -94,13 +94,28 @@ describe Teaspoon::Instrumentation do
       expect(subject.add?([404, { "Content-Type" => "application/javascript" }, []], env)).to_not be(true)
     end
 
-    it "doesn't when the asset is in the ignore list" do
-      asset = double(
-        source: source,
-        pathname: "path/to/ignored_files/instrument.js"
-      )
-      allow(Teaspoon.configuration).to receive(:coverage_ignored).and_return(["/ignored_files/"])
-      expect(subject.add?([200, { "Content-Type" => "application/javascript" }, asset], env)).to_not be(true)
+    describe "Ignored Coverage" do
+      context "with a String" do
+        it "doesn't when the asset is in the coverage_ignored list" do
+          allow(Teaspoon.configuration).to receive(:coverage_ignored).and_return(["/ignored_files/"])
+          asset = double(
+            source: source,
+            pathname: "path/to/ignored_files/instrument.js"
+            )
+          expect(subject.add?([200, { "Content-Type" => "application/javascript" }, asset], env)).to_not be(true)
+        end
+      end
+
+      context "with a Regular Expression" do
+        it "doesn't when the asset is in the coverage_ignored list" do
+          allow(Teaspoon.configuration).to receive(:coverage_ignored).and_return([%r{/ignored_files/}])
+          asset = double(
+            source: source,
+            pathname: "path/to/ignored_files/instrument.js"
+            )
+          expect(subject.add?([200, { "Content-Type" => "application/javascript" }, asset], env)).to_not be(true)
+        end
+      end
     end
 
   end

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -99,7 +99,7 @@ describe Teaspoon::Instrumentation do
         source: source,
         pathname: "path/to/ignored_files/instrument.js"
       )
-      allow(Teaspoon.configuration).to receive(:coverage_ignored_files).and_return(["/ignored_files/"])
+      allow(Teaspoon.configuration).to receive(:coverage_ignored).and_return(["/ignored_files/"])
       expect(subject.add?([200, { "Content-Type" => "application/javascript" }, asset], env)).to_not be(true)
     end
 

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -94,6 +94,15 @@ describe Teaspoon::Instrumentation do
       expect(subject.add?([404, { "Content-Type" => "application/javascript" }, []], env)).to_not be(true)
     end
 
+    it "doesn't when the asset is in the ignore list" do
+      asset = double(
+        source: source,
+        pathname: "path/to/ignored_files/instrument.js"
+      )
+      allow(Teaspoon.configuration).to receive(:coverage_ignored_files).and_return(["/ignored_files/"])
+      expect(subject.add?([200, { "Content-Type" => "application/javascript" }, asset], env)).to_not be(true)
+    end
+
   end
 
   describe "integration" do


### PR DESCRIPTION
This is an initial attempt at including a configuration option to filter files being instrumented by Istanbul.

I've added the configuration at the top level as the `coverage` configuration is based on a suite which it not available from within `Teaspoon::Instrumentation`.
This is currently allowing me to define a list of strings which are then used as regular expressions to check against the assets pathname.

Initial discussion was here: #315.