### PR TITLE
Require javascripts to be defined in suite configs.

### DIFF
--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -84,7 +84,12 @@ module Teaspoon
 
         default = Teaspoon.configuration.suite_configs["default"]
         instance_eval(&default[:block]) if default
-        yield self if block_given?
+        if block_given?
+          yield self
+          if @javascripts.length == 0
+            raise Teaspoon::FrameworkUnspecified, "Expected a framework to be configured using `suite.use_framework`."
+          end
+        end
       end
 
       def use_framework(name, version = nil)

--- a/lib/teaspoon/exceptions.rb
+++ b/lib/teaspoon/exceptions.rb
@@ -5,6 +5,7 @@ module Teaspoon
   class ServerException < Teaspoon::Error; end
   class RunnerException < Teaspoon::Error; end
   class ExporterException < Teaspoon::Error; end
+  class FrameworkUnspecified < Teaspoon::Error; end
   class UnknownFramework < Teaspoon::Error; end
   class UnknownCoverage < Teaspoon::Error; end
   class UnknownDriver < Teaspoon::Error; end

--- a/spec/features/hooks_spec.rb
+++ b/spec/features/hooks_spec.rb
@@ -6,11 +6,28 @@ feature "testing hooks in the browser" do
   include Rack::Test::Methods
 
   let(:app) { Dummy::Application }
-  let(:suites) {{
-    "suite1" => {block: proc{ |suite| suite.hook :before, &proc{ File.write(temp_file, "") } }},
-    "suite2" => {block: proc{ |suite| suite.hook :after, &proc{ File.write(temp_file, "") } }},
-    "suite3" => {block: proc{ |suite| suite.hook :with_arguments, &proc{ |args| File.write(temp_file, args["message"]) } }},
-  }}
+  let(:suites) do
+    {
+      "suite1" => {
+        block: proc{ |c|
+          c.javascripts = ["foo"]
+          c.hook :before, &proc{ File.write(temp_file, "") }
+        }
+      },
+      "suite2" => {
+        block: proc{ |c|
+          c.javascripts = ["foo"]
+          c.hook :after, &proc{ File.write(temp_file, "") }
+        }
+      },
+      "suite3" => {
+        block: proc{ |c|
+          c.javascripts = ["foo"]
+          c.hook :with_arguments, &proc{ |args| File.write(temp_file, args["message"]) }
+        }
+      },
+    }
+  end
 
   before do
     allow(Teaspoon.configuration).to receive(:suite_configs).and_return(suites)

--- a/spec/features/html_reporter_spec.rb
+++ b/spec/features/html_reporter_spec.rb
@@ -6,10 +6,13 @@ feature "testing with teaspoon in the browser", js: true do
 
   before do
     Teaspoon::Suite.instance_variable_set(:@all, nil)
-    allow(Teaspoon.configuration).to receive(:suite_configs).and_return "integration" => {block: proc{ |suite|
-      suite.matcher = "spec/dummy/app/assets/javascripts/integration/*_spec.{js,js.coffee,coffee}"
-      suite.helper = spec_helper
-    }}
+    allow(Teaspoon.configuration).to receive(:suite_configs).and_return "integration" => {
+      block: proc{ |c|
+        c.matcher = "spec/dummy/app/assets/javascripts/integration/*_spec.{js,js.coffee,coffee}"
+        c.helper = spec_helper
+        c.javascripts = ["jasmine/1.3.1", "teaspoon-jasmine"]
+      }
+    }
   end
 
   scenario "lists the suites" do

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -208,6 +208,14 @@ describe Teaspoon::Configuration::Suite do
         )
       end
 
+      it "shows an error when there are no javascripts configured" do
+        @suite = proc{ |s| s.javascripts = [] }
+        expect{ subject }.to raise_error(
+            Teaspoon::FrameworkUnspecified,
+            "Expected a framework to be configured using `suite.use_framework`."
+          )
+      end
+
     end
 
   end

--- a/spec/teaspoon/server_spec.rb
+++ b/spec/teaspoon/server_spec.rb
@@ -90,7 +90,8 @@ describe Teaspoon::Server do
   describe "integration" do
 
     before do
-      allow(Teaspoon.configuration).to receive(:suite_configs).and_return("foo" => { block: proc {} })
+      suite_config = proc { |c| c.javascripts = ["foo"] }
+      allow(Teaspoon.configuration).to receive(:suite_configs).and_return("foo" => {block: suite_config})
       allow(Teaspoon.configuration).to receive(:suppress_log).and_return(true)
     end
 

--- a/spec/teaspoon/suite_spec.rb
+++ b/spec/teaspoon/suite_spec.rb
@@ -2,15 +2,17 @@ require "spec_helper"
 
 describe Teaspoon::Suite do
 
+  let(:suite_config) { {block: proc { |c| c.javascripts = ['foo'] }} }
+
   before do
-    allow(Teaspoon.configuration).to receive(:suite_configs).and_return("default" => { block: proc {} })
+    allow(Teaspoon.configuration).to receive(:suite_configs).and_return("default" => suite_config)
   end
 
   describe ".all" do
 
     before do
       Teaspoon::Suite.instance_variable_set(:@all, nil)
-      suites = { "default" => { block: proc {} }, "foo" => { block: proc {} } }
+      suites = { "default" => suite_config, "foo" => suite_config }
       allow(Teaspoon.configuration).to receive(:suite_configs).and_return(suites)
     end
 


### PR DESCRIPTION
This forces javascripts to be specified.. currently not very useful, but will become more useful during the transition phase where users may not have a framework installed/required.