### PR TITLE
Add responder to handle hooks in one place

### DIFF
--- a/app/assets/javascripts/teaspoon/jasmine2.coffee
+++ b/app/assets/javascripts/teaspoon/jasmine2.coffee
@@ -1,4 +1,6 @@
 #= require teaspoon/base/teaspoon
+#= require teaspoon/jasmine2/_namespace
+#= require teaspoon/jasmine2/responder
 #= require teaspoon/jasmine2/reporters/console
 #= require teaspoon/jasmine2/reporters/html
 
@@ -24,9 +26,10 @@ class Teaspoon.Runner extends Teaspoon.Runner
 
 
   setup: ->
-    # add the reporter and set the filter
+    # add the responder
     reporter = new (@getReporter())()
-    env.addReporter(reporter)
+    responder = new Teaspoon.Jasmine2.Responder(reporter)
+    env.addReporter(responder)
 
     # add fixture support
     @addFixtureSupport()

--- a/app/assets/javascripts/teaspoon/jasmine2/_namespace.coffee
+++ b/app/assets/javascripts/teaspoon/jasmine2/_namespace.coffee
@@ -1,0 +1,2 @@
+@Teaspoon ?= {}
+@Teaspoon.Jasmine2 ?= {}

--- a/app/assets/javascripts/teaspoon/jasmine2/reporters/console.coffee
+++ b/app/assets/javascripts/teaspoon/jasmine2/reporters/console.coffee
@@ -1,9 +1,5 @@
 class Teaspoon.Reporters.Console extends Teaspoon.Reporters.Console
 
-  jasmineStarted: ->
-    @reportRunnerStarting()
-
-
   reportRunnerStarting: ->
     @currentAssertions = []
     @log
@@ -12,28 +8,9 @@ class Teaspoon.Reporters.Console extends Teaspoon.Reporters.Console
       start: JSON.parse(JSON.stringify(@start))
 
 
-  jasmineDone: ->
-    @reportRunnerResults()
-
-
   reportRunnerResults: =>
     @log
       type:    "result"
       elapsed: ((new Teaspoon.Date().getTime() - @start.getTime()) / 1000).toFixed(5)
       coverage: window.__coverage__
     Teaspoon.finished = true
-
-
-  suiteStarted: (result) ->
-    if @currentSuite # suite already running, we're nested
-      result.parent = @currentSuite
-    @currentSuite = result
-
-
-  suiteDone: (result) ->
-    @currentSuite = @currentSuite.parent
-
-
-  specDone: (result) ->
-    result.parent = @currentSuite
-    @reportSpecResults(result)

--- a/app/assets/javascripts/teaspoon/jasmine2/reporters/html.coffee
+++ b/app/assets/javascripts/teaspoon/jasmine2/reporters/html.coffee
@@ -7,35 +7,3 @@ class Teaspoon.Reporters.HTML extends Teaspoon.Reporters.HTML
 
   envInfo: ->
     "jasmine #{jasmine.version}"
-
-
-  jasmineStarted: (result) ->
-    @reportRunnerStarting(total: result.totalSpecsDefined)
-
-
-  jasmineDone: ->
-    @reportRunnerResults()
-
-
-  suiteStarted: (result) ->
-    if @currentSuite # suite already running, we're nested
-      result.parent = @currentSuite
-    @currentSuite = result
-
-
-  suiteDone: (result) ->
-    @currentSuite = @currentSuite.parent
-
-
-  specStarted: (result) ->
-    # Jasmine 2 reports the spec starting even though it may
-    # be filtered out, but there's no way to tell.
-    # TODO: Is there a way to clean this up?
-    if jasmine.getEnv().specFilter(getFullName: -> result.fullName)
-      result.parent = @currentSuite
-      @reportSpecStarting(result)
-
-
-  specDone: (result) ->
-    result.parent = @currentSuite
-    @reportSpecResults(result)

--- a/app/assets/javascripts/teaspoon/jasmine2/responder.coffee
+++ b/app/assets/javascripts/teaspoon/jasmine2/responder.coffee
@@ -1,0 +1,47 @@
+class Teaspoon.Jasmine2.Responder extends Teaspoon.Runner
+
+  constructor: (@reporter) ->
+
+  
+  jasmineStarted: (result) ->
+    @reporter.reportRunnerStarting(total: result.totalSpecsDefined)
+
+  
+  jasmineDone: ->
+    @reporter.reportRunnerResults()
+
+
+  suiteStarted: (result) ->
+    if @currentSuite # suite already running, we're nested
+      result.parent = @currentSuite
+    @currentSuite = result
+
+    @reporter.reportSuiteStarting?(
+      id: result.id
+      description: result.description
+      fullName: result.fullName
+    )
+
+
+  suiteDone: (result) ->
+    @currentSuite = @currentSuite.parent
+
+    @reporter.reportSuiteResults?(
+      id: result.id
+      description: result.description
+      fullName: result.fullName
+    )
+
+
+  specStarted: (result) ->
+    # Jasmine 2 reports the spec starting even though it may
+    # be filtered out, but there's no way to tell.
+    # TODO: Is there a way to clean this up?
+    if jasmine.getEnv().specFilter(getFullName: -> result.fullName)
+      result.parent = @currentSuite
+      @reporter.reportSpecStarting?(result)
+
+
+  specDone: (result) ->
+    result.parent = @currentSuite
+    @reporter.reportSpecResults(result)

--- a/spec/javascripts/teaspoon/jasmine2/fixture_j2spec.coffee
+++ b/spec/javascripts/teaspoon/jasmine2/fixture_j2spec.coffee
@@ -1,6 +1,6 @@
 fixture.preload("fixture.html", "fixture.json") # make the actual requests for the files
 # fixture.set("<h2>Another Title</h2>") # create some markup manually (will be in a beforeEach)
-describe "Using fixtures", ->
+describe "Using fixtures in Jasmine 2", ->
 
   fixture.set("<h2>Another Title</h2>") # create some markup manually (will be in a beforeEach)
 

--- a/spec/javascripts/teaspoon/jasmine2/responder_j2spec.coffee
+++ b/spec/javascripts/teaspoon/jasmine2/responder_j2spec.coffee
@@ -1,0 +1,192 @@
+describe "Jasmine 2 describe", ->
+
+  beforeEach ->
+    @jasmineStartedDetails =
+      totalSpecsDefined: 42
+    @suiteStartedDetails =
+      id: "suite1"
+      description: "Jasmine 2 describe"
+      fullName: "Jasmine 2 describe"
+      failedExpectations: []
+    @suiteDoneDetails =
+      id: "suite1"
+      description: "Jasmine 2 describe"
+      fullName: "Jasmine 2 describe"
+      failedExpectations: []
+      status: "finished"
+    @specStartedDetails =
+      id: "spec0"
+      description: "has an it"
+      fullName: "Jasmine 2 describe has an it"
+      failedExpectations: []
+      passedExpectations: []
+      pendingReason: ""
+    @specDoneDetails =
+      id: "spec0"
+      description: "has an it"
+      fullName: "Jasmine 2 describe has an it"
+      failedExpectations: []
+      passedExpectations: [
+        matcherName: "toEqual"
+        message: "Passed."
+        passed: true
+        stack: ""
+      ]
+      pendingReason: ""
+      status: "passed"
+
+    @reporter =
+      reportRunnerStarting: ->
+      reportRunnerResults: ->
+      reportSuiteStarting: ->
+      reportSuiteResults: ->
+      reportSpecStarting: ->
+      reportSpecResults: ->
+    @responder = new Teaspoon.Jasmine2.Responder(@reporter)
+
+
+  describe "#jasmineStarted", ->
+
+    it "has an it", ->
+      spyOn(@reporter, 'reportRunnerStarting')
+
+      @responder.jasmineStarted(@jasmineStartedDetails)
+
+      expect(@reporter.reportRunnerStarting).toHaveBeenCalledWith(total: 42)
+
+
+  describe "#jasmineDone", ->
+
+    it "reports the runner finishing", ->
+      spyOn(@reporter, 'reportRunnerResults')
+
+      @responder.jasmineDone()
+
+      expect(@reporter.reportRunnerResults).toHaveBeenCalled()
+
+
+  describe "#suiteStarted", ->
+
+    it "reports the suite starting", ->
+      spyOn(@reporter, 'reportSuiteStarting')
+
+      @responder.suiteStarted(@suiteStartedDetails)
+
+      expect(@reporter.reportSuiteStarting).toHaveBeenCalledWith
+        id: "suite1"
+        description: "Jasmine 2 describe"
+        fullName: "Jasmine 2 describe"
+
+
+    it "does not error out if the reporter doesn't care about starting suites", ->
+      delete @reporter.reportSuiteStarting
+
+      expect(=>
+        @responder.suiteStarted(@suiteStartedDetails)
+      ).not.toThrow()
+
+
+  describe "#suiteDone", ->
+
+    beforeEach ->
+      @responder.currentSuite = {}
+
+
+    it "reports the suite finishing", ->
+      spyOn(@reporter, 'reportSuiteResults')
+
+      @responder.suiteDone(@suiteDoneDetails)
+
+      expect(@reporter.reportSuiteResults).toHaveBeenCalledWith
+        id: "suite1"
+        description: "Jasmine 2 describe"
+        fullName: "Jasmine 2 describe"
+
+
+    it "does not error out if the reporter doesn't care about finishing suites", ->
+      delete @reporter.reportSuiteResults
+
+      expect(=>
+        @responder.suiteDone(@suiteDoneDetails)
+      ).not.toThrow()
+
+
+  describe "#specStarted", ->
+
+    it "reports the spec starting", ->
+      spyOn(@reporter, 'reportSpecStarting')
+
+      @responder.specStarted(@specStartedDetails)
+
+      expect(@reporter.reportSpecStarting).toHaveBeenCalledWith
+        id: "spec0"
+        description: "has an it"
+        fullName: "Jasmine 2 describe has an it"
+        failedExpectations: []
+        passedExpectations: []
+        pendingReason: ""
+        parent: undefined
+
+
+    it "does not error out if the reporter doesn't care about starting specs", ->
+      delete @reporter.reportSpecStarting
+
+      expect(=>
+        @responder.specStarted(@specStartedDetails)
+      ).not.toThrow()
+
+
+  describe "#specDone", ->
+
+    it "reports the spec finishing", ->
+      spyOn(@reporter, 'reportSpecResults')
+
+      @responder.specDone(@specDoneDetails)
+
+      expect(@reporter.reportSpecResults).toHaveBeenCalledWith
+        id: "spec0"
+        description: "has an it"
+        fullName: "Jasmine 2 describe has an it"
+        failedExpectations: []
+        passedExpectations: [
+          matcherName: "toEqual"
+          message: "Passed."
+          passed: true
+          stack: ""
+        ]
+        pendingReason: ""
+        status: "passed"
+        parent: undefined
+
+
+  describe "nested suites and specs", ->
+
+    beforeEach ->
+      spyOn(jasmine.getEnv(), 'specFilter').and.returnValue(true)
+
+
+    it "tracks the parent suite", ->
+      # Mimicking the following setup:
+      # describe "a", ->
+      #   describe "b", ->
+      #     it "a"
+      #   describe "c", ->
+
+      suitea = {}
+      suiteb = {}
+      speca = {fullName: ''}
+      suitec = {}
+
+      @responder.suiteStarted(suitea)
+      @responder.suiteStarted(suiteb)
+      @responder.specStarted(speca)
+      @responder.specDone(speca)
+      @responder.suiteDone(suiteb)
+      @responder.suiteStarted(suitec)
+      @responder.suiteDone(suitec)
+      @responder.suiteDone(suitea)
+
+      expect(suitea.parent).toBeUndefined()
+      expect(suiteb.parent).toEqual(suitea)
+      expect(speca.parent).toEqual(suiteb)
+      expect(suitec.parent).toEqual(suitea)


### PR DESCRIPTION
This adds the responder abstraction between the reporter and the framework. This accomplishes the following:

- Give a clear place to see how Teaspoon hooks into a framework
- DRY up the console and HTML reporters so they don't both have to provide framework hooks