### PR TITLE
Add ES6 extensions to normalize_js_extension.

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -97,7 +97,7 @@ module Teaspoon
     end
 
     def normalize_js_extension(filename)
-      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee)$/, ".js")
+      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6)$/, ".js")
     end
 
     def glob


### PR DESCRIPTION
This super-insignificant tweak adds `.es6` and `.js.es6` to the preprocessors filtered out by the `normalize_js_extension` method. I'd like to come back to it at some point and see if it's at all feasible to futureproof it by extracting preprocessor extensions from the `suite.matcher` setting, but don't have the time just now.