### PR TITLE
Do not double load teaspoon_env

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -5,6 +5,7 @@ module Teaspoon
     def initialize(options = {})
       @default_options = options
       @suites = {}
+      Teaspoon::Environment.console = true
       Teaspoon::Environment.load(options)
 
       @server = start_server

--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -15,7 +15,9 @@ module Teaspoon
 
     initializer :assets, group: :all do |app|
       begin
-        Teaspoon::Environment.require_environment
+        if Teaspoon::Environment.require_environment_from_engine?
+          Teaspoon::Environment.require_environment
+        end
       rescue Teaspoon::EnvironmentNotFound
         # it's ok for this to fail sometimes, like before the generator is run etc
       end

--- a/lib/teaspoon/environment.rb
+++ b/lib/teaspoon/environment.rb
@@ -2,6 +2,11 @@ require "teaspoon/exceptions"
 
 module Teaspoon
   module Environment
+    class << self
+      attr_accessor :console
+      alias :console? :console
+    end
+
     def self.load(options = {})
       require_environment(options[:environment])
       raise "Rails environment not found." unless rails_loaded?
@@ -37,6 +42,12 @@ module Teaspoon
       ["spec/teaspoon_env.rb", "test/teaspoon_env.rb", "teaspoon_env.rb"]
     end
 
+    def self.require_environment_from_engine?
+      # Console has already loaded the environment at this point. Console loads teaspoon_env,
+      # which loads Rails, which loads the engine. So, no need to load teaspoon_env again.
+      !console?
+    end
+
     private
 
     def self.require_env(file)
@@ -44,7 +55,7 @@ module Teaspoon
     end
 
     def self.rails_loaded?
-      defined?(Rails)
+      !!defined?(Rails)
     end
   end
 end

--- a/spec/teaspoon/environment_spec.rb
+++ b/spec/teaspoon/environment_spec.rb
@@ -98,10 +98,27 @@ describe Teaspoon::Environment do
 
   end
 
+  describe ".require_environment_from_engine?" do
+
+    after do
+      subject.console = false
+    end
+
+    it "returns true if not run from within the console" do
+      expect(subject.require_environment_from_engine?).to eql(true)
+    end
+
+    it "returns false if run from within the console" do
+      subject.console = true
+      expect(subject.require_environment_from_engine?).to eql(false)
+    end
+
+  end
+
   describe ".rails_loaded?" do
 
     it "returns a boolean based on if Rails is defined" do
-      expect(subject.send(:rails_loaded?)).to be_truthy
+      expect(subject.send(:rails_loaded?)).to eql(true)
     end
 
   end


### PR DESCRIPTION
- When loading from the console, we need to load the Rails env, so we load the app's teaspoon_env. When we load teaspoon_env, the app then loads all engines, including teaspoon. Previously, this double loaded teaspoon_env and caused multiplicative effects on configurations that accumulate values, like #hooks.

- Updates the predicate method `rails_loaded?` to always return a boolean

- Converts `environment.rb` to group methods on the singleton (`class << self`)

Fixes #332
