### PR TITLE
Load Rails, which will load teaspoon_env

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ end
 # Dummy App
 # -----------------------------------------------------------------------------
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
+ENV["TEASPOON_RAILS_ENV"] = File.expand_path("../spec/dummy/config/environment.rb", __FILE__)
 load "rails/tasks/engine.rake"
 begin
   Bundler::GemHelper.install_tasks

--- a/lib/generators/teaspoon/install/templates/env.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env.rb.tt
@@ -1,9 +1,3 @@
-# Set RAILS_ROOT and load the environment if it's not already loaded.
-unless defined?(Rails)
-  ENV["RAILS_ROOT"] = File.expand_path("../../", __FILE__)
-  require File.expand_path("../../config/environment", __FILE__)
-end
-
 Teaspoon.configure do |config|
   config.mount_at = "/teaspoon"
   config.root = nil

--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -1,9 +1,3 @@
-# Set RAILS_ROOT and load the environment if it's not already loaded.
-unless defined?(Rails)
-  ENV["RAILS_ROOT"] = File.expand_path("../../", __FILE__)
-  require File.expand_path("../../config/environment", __FILE__)
-end
-
 Teaspoon.configure do |config|
   # Determines where the Teaspoon routes will be mounted. Changing this to "/jasmine" would allow you to browse to
   # `http://localhost:3000/jasmine` to run your tests.

--- a/lib/teaspoon/environment.rb
+++ b/lib/teaspoon/environment.rb
@@ -3,7 +3,7 @@ require "teaspoon/exceptions"
 module Teaspoon
   module Environment
     def self.load(options = {})
-      require_environment(options[:environment])
+      load_rails
       Teaspoon.abort("Rails environment not found.", 1) unless rails_loaded?
 
       require "teaspoon"
@@ -44,6 +44,11 @@ module Teaspoon
 
     def self.rails_loaded?
       !!defined?(Rails)
+    end
+
+    def self.load_rails
+      rails_env = ENV["TEASPOON_RAILS_ENV"] || File.expand_path("config/environment", Dir.pwd)
+      require rails_env
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ end
 
 ENV["RAILS_ENV"] ||= "test"
 ENV["RAILS_ROOT"] = File.expand_path("../dummy", __FILE__)
+ENV["TEASPOON_RAILS_ENV"] = File.expand_path("../dummy/config/environment.rb", __FILE__)
 require File.expand_path("../dummy/config/environment", __FILE__)
 
 require "rspec/rails"

--- a/spec/support/teaspoon_devkit.rb
+++ b/spec/support/teaspoon_devkit.rb
@@ -29,10 +29,12 @@ module Teaspoon
     end
 
     def run_teaspoon(opts = "")
+      set_rails_env
       run_simple("bundle exec teaspoon #{opts}", false)
     end
 
     def rake_teaspoon(envs = "")
+      set_rails_env
       run_simple("bundle exec rake teaspoon #{envs}", false)
     end
 
@@ -51,6 +53,11 @@ module Teaspoon
       output = output.gsub("'undefined' is not a function", "undefined is not a constructor")
       output = output.gsub(/Finished in [\d\.]+ seconds/, "Finished in 0.31337 seconds")
       output
+    end
+
+    def set_rails_env
+      boot_from = File.expand_path(current_dir + "/config/environment.rb", Dir.pwd)
+      set_env("TEASPOON_RAILS_ENV", boot_from)
     end
   end
 end

--- a/spec/teaspoon/environment_spec.rb
+++ b/spec/teaspoon/environment_spec.rb
@@ -5,14 +5,17 @@ describe Teaspoon::Environment do
   subject { described_class }
 
   describe ".load" do
+    before do
+      allow(subject).to receive(:load_rails)
+    end
+
     it "calls require_environment" do
-      expect(subject).to receive(:require_environment)
+      expect(subject).to receive(:load_rails)
       expect(subject).to receive(:rails_loaded?).and_return(true)
       described_class.load
     end
 
     it "aborts if Rails can't be found" do
-      expect(subject).to receive(:require_environment)
       expect(subject).to receive(:rails_loaded?).and_return(false)
       expect(Teaspoon).to receive(:abort).with("Rails environment not found.", 1)
       described_class.load

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,9 +1,3 @@
-# Set RAILS_ROOT and load the environment if it's not already loaded.
-unless defined?(Rails)
-  ENV["RAILS_ROOT"] = File.expand_path("../dummy", __FILE__)
-  require File.expand_path("../dummy/config/environment", __FILE__)
-end
-
 Teaspoon.configure do |config|
   config.root = Teaspoon::Engine.root
   config.asset_paths << Teaspoon::Engine.root.join("lib/teaspoon")


### PR DESCRIPTION
If we always load Rails, we can assume that `teaspoon_env.rb` will get loaded as part of the engine initialization. This doesn't help us move away from Rails, but it's the simplest way to ensure that `teaspoon_env.rb` is only being required once, without limiting any behavior.

Additional:
- :+1: Removes the needs for `teaspoon_env.rb` to load the Rails environment which I think is cleaner. If we want to go the direction of this PR, I propose we rename this file to `teaspoon.rb`.
- :-1: We now need to know how to boot Rails. I've added the `TEASPOON_RAILS_ENV` env var to make this overridable. Works with a stock setup, but is required every time we run teaspoon tests using the dummy app's `environment.rb`.
- :-1: Ties us even closer to Rails.
- :+1: Is less code than my previous approach #340 (which I've since reverted in master).

Fixes #341