### PR TITLE
Allow alternative catch-all routes to be specified

### DIFF
--- a/lib/generators/teaspoon/install/templates/env.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env.rb.tt
@@ -1,5 +1,6 @@
 Teaspoon.configure do |config|
   config.mount_at = "/teaspoon"
+  config.catchall = nil
   config.root = nil
   config.asset_paths = ["<%= framework.install_path %>/javascripts", "<%= framework.install_path %>/javascripts/stylesheets"]
   config.fixture_paths = ["<%= framework.install_path %>/javascripts/fixtures"]

--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -3,6 +3,11 @@ Teaspoon.configure do |config|
   # `http://localhost:3000/jasmine` to run your tests.
   config.mount_at = "/teaspoon"
 
+  # Sets an alternative catch-all action to check when mounting Teaspoon routes. For example, if your application
+  # imposes a catch-all like `get "*path", to: "errors#not_found"`, you should set this to "not_found".
+  # Note: Defaults to "routing_error" if nil.
+  config.catchall = nil
+
   # Specifies the root where Teaspoon will look for files. If you're testing an engine using a dummy application it can
   # be useful to set this to your engines root (e.g. `Teaspoon::Engine.root`).
   # Note: Defaults to `Rails.root` if nil.
@@ -62,7 +67,7 @@ Teaspoon.configure do |config|
     #suite.hook :fixtures, proc{ }
 
     # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
-    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default, 
+    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default,
     # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
     #suite.expand_assets = false
   end

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -16,8 +16,9 @@ module Teaspoon
     # - add it to ENV_OVERRIDES if it can be overridden from ENV
     # - add it to the initializers in /lib/generators/install/templates so it's documented there as well
 
-    cattr_accessor :mount_at, :root, :asset_paths, :fixture_paths, :asset_manifest
+    cattr_accessor :mount_at, :root, :asset_paths, :fixture_paths, :asset_manifest, :catchall
     @@mount_at       = "/teaspoon"
+    @@catchall       = nil # will default to "routing_error"
     @@root           = nil # will default to Rails.root
     @@asset_paths    = ["spec/javascripts", "spec/javascripts/stylesheets",
                         "test/javascripts", "test/javascripts/stylesheets"]

--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -55,8 +55,9 @@ module Teaspoon
 
     def self.prepend_routes(app)
       mount_at = Teaspoon.configuration.mount_at
+      catchall = Teaspoon.configuration.catchall || "routing_error"
 
-      return if app.routes.recognize_path(mount_at)[:action] != "routing_error" rescue nil
+      return if app.routes.recognize_path(mount_at)[:action] != catchall rescue nil
       require Teaspoon::Engine.root.join("app/controllers/teaspoon/suite_controller")
 
       app.routes.prepend { mount Teaspoon::Engine => mount_at, as: "teaspoon" }


### PR DESCRIPTION
We currently prepend Teaspoon’s routes in an effort to prevent catch-all
routes from intercepting traffic intended for the Teaspoon engine.

_However_, recent changes have hard-coded “routing_error” as the only
viable catch-all action, meaning that any custom catch-all routing will
prevent Teaspoon’s routes from being prepended. The solution I’ve opted
for here is to allow users to specify their custom catch-all action, so
that Teaspoon can still properly mount when a path is undefined.