### PR TITLE
Speedup javascript_include_tag.

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -75,8 +75,8 @@ module Teaspoon
     end
 
     def asset_url(asset)
-      params = "?body=1"
-      params << "&instrument=1" if instrument_file?(asset.pathname.to_s)
+      params = ""
+      params << "?body=1&instrument=1" if instrument_file?(asset.pathname.to_s)
       "#{asset.logical_path}#{params}"
     end
 

--- a/spec/teaspoon/suite_spec.rb
+++ b/spec/teaspoon/suite_spec.rb
@@ -76,8 +76,8 @@ describe Teaspoon::Suite do
   describe "#spec_assets" do
     it "returns an array of assets" do
       result = subject.spec_assets
-      expect(result).to include("spec_helper.self.js?body=1")
-      expect(result).to include("teaspoon/reporters/console_spec.self.js?body=1")
+      expect(result).to include("spec_helper.self.js")
+      expect(result).to include("teaspoon/reporters/console_spec.self.js")
     end
 
     it "returns just a file if one was requested" do
@@ -90,8 +90,8 @@ describe Teaspoon::Suite do
       allow(subject).to receive(:no_coverage).and_return([%r{support/}, "spec_helper.coffee"])
       subject.instance_variable_set(:@options, coverage: true)
       result = subject.spec_assets(true)
-      expect(result).to include("support/json2.self.js?body=1")
-      expect(result).to include("spec_helper.self.js?body=1")
+      expect(result).to include("support/json2.self.js")
+      expect(result).to include("spec_helper.self.js")
       expect(result).to include("drivers/phantomjs/runner.self.js?body=1&instrument=1")
     end
 


### PR DESCRIPTION
Appending ?body=1 to all assets make javascript_include_tag very slow.

So only append it to instrumented file and let sprockets to his job for
others files.

In our app, performance improvements with this patch are quite impressive (527 JavaScript files so far)

I instrumented _boot.html.erb:

```ruby
<% puts Benchmark.measure { %>
<%= javascript_include_tag *@suite.spec_assets %>
<% } %>
<script type="text/javascript">
  Teaspoon.onWindowLoad(Teaspoon.execute);
</script>
```

Without the patch: `12.500000   0.500000  13.000000 ( 13.000034)`
With the patch: `3.140000   0.120000   3.260000 (  3.256158)`