### PR TITLE
Support use_coverage = true. Throw ex when !istanbul

### DIFF
--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -143,9 +143,14 @@ Teaspoon.configure do |config|
   # - with the rake task: rake teaspoon USE_COVERAGE=[coverage_name]
   # - with the cli: teaspoon --coverage=[coverage_name]
 
-  # Specify that you always want a coverage configuration to be used.
+  # Specify that you always want a coverage configuration to be used. Otherwise, specify that you want coverage
+  # on the CLI.
+  # Set this to "true" or the name of your coverage config.
   #config.use_coverage = nil
 
+  # You can have multiple coverage configs by passing a name to config.coverage.
+  # e.g. config.coverage :ci do |coverage|
+  # The default coverage config name is :default.
   config.coverage do |coverage|
     # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.
     #

--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -4,7 +4,7 @@ module Teaspoon
       @suite_name = suite_name
       @data = data
       @executable = Teaspoon::Instrumentation.executable
-      @config = coverage_configuration(config_name.to_s)
+      @config = coverage_configuration(normalize_config_name(config_name))
     end
 
     def generate_reports(&block)
@@ -57,6 +57,11 @@ module Teaspoon
         threshold = @config.send(:"#{assert}")
         "--#{assert}=#{threshold}" if threshold
       end.compact
+    end
+
+    def normalize_config_name(name)
+      return "default" if name == true
+      name.to_s
     end
   end
 end

--- a/lib/teaspoon/exceptions.rb
+++ b/lib/teaspoon/exceptions.rb
@@ -146,4 +146,11 @@ module Teaspoon
       super(msg)
     end
   end
+
+  class IstanbulNotFoundError < Teaspoon::Error
+    def initialize(msg = nil)
+      msg ||= "You requested coverage reports, but Teaspoon cannot find the istanbul binary. Run: npm install -g istanbul"
+      super(msg)
+    end
+  end
 end

--- a/lib/teaspoon/runner.rb
+++ b/lib/teaspoon/runner.rb
@@ -55,7 +55,10 @@ module Teaspoon
     end
 
     def resolve_coverage(data)
-      return unless Teaspoon.configuration.use_coverage && data.present?
+      return unless Teaspoon.configuration.use_coverage
+      raise Teaspoon::IstanbulNotFoundError unless Teaspoon::Instrumentation.executable
+      return unless data.present?
+
       coverage = Teaspoon::Coverage.new(@suite_name, Teaspoon.configuration.use_coverage, data)
       coverage.generate_reports { |msg| notify_formatters("coverage", msg) }
       coverage.check_thresholds do |msg|

--- a/spec/teaspoon/coverage_spec.rb
+++ b/spec/teaspoon/coverage_spec.rb
@@ -27,6 +27,11 @@ describe Teaspoon::Coverage do
       described_class.new("_suite_", :default, data)
     end
 
+    it "allows true in place of :default" do
+      expect_any_instance_of(described_class).to receive(:coverage_configuration).with("default")
+      described_class.new("_suite_", true, data)
+    end
+
     it "raises an exception if the coverage config can't be found" do
       expect { described_class.new("_suite_", :foo, data) }.to raise_error(
         Teaspoon::UnknownCoverage,

--- a/spec/teaspoon/runner_spec.rb
+++ b/spec/teaspoon/runner_spec.rb
@@ -94,6 +94,13 @@ describe Teaspoon::Runner do
         subject.process('{"_teaspoon":true,"type":"result","coverage":"_coverage_"}')
         expect(subject.failure_count).to eq(1)
       end
+
+      it "raises an exception when istanbul cannot be found if coverage is requested" do
+        expect(Teaspoon.configuration).to receive(:use_coverage).and_return("_config_")
+        expect(Teaspoon::Instrumentation).to receive(:executable).and_return(nil)
+
+        expect { subject.process('{"_teaspoon":true,"type":"result","coverage":"_coverage_"}') }.to raise_error(Teaspoon::IstanbulNotFoundError)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR does 2 things:

1. Supports `config.use_coverage = true` which I feel is more intuitive with the default config. Adds docs.
1. Throw an exception when istanbul is not available but coverage has been requested.