### PR TITLE
Add coverage.ignore option in place of suite.no_coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 * Provide QUnit tests with a default `equal` message
 * Support cli reusing running Rails server
 * Add support for Capybara Webkit
-* Better support for RequireJS
+* Better support for RequireJS and more consistent coverage configuration (@davestevens)
 * Add RSpec HTML formatter
 
 #### Bug Fixes

--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -53,10 +53,6 @@ Teaspoon.configure do |config|
     # Partial to be rendered in the body tag of the runner. You can define your own to create a custom body structure.
     suite.body_partial = <%= suite.body_partial.inspect %>
 
-    # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
-    # default excludes assets from vendor, gems and support libraries.
-    #suite.no_coverage = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
-
     # Hooks allow you to use `Teaspoon.hook("fixtures")` before, after, or during your spec run. This will make a
     # synchronous Ajax request to the server that will call all of the blocks you've defined for that hook name.
     #suite.hook :fixtures, proc{ }
@@ -160,6 +156,10 @@ Teaspoon.configure do |config|
     # The path that the coverage should be written to - when there's an artifact to write to disk.
     # Note: Relative to `config.root`.
     #coverage.output_path = "coverage"
+
+    # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
+    # default excludes assets from vendor, gems and support libraries.
+    #coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
 
     # Various thresholds requirements can be defined, and those thresholds will be checked at the end of a run. If any
     # aren't met the run will fail with a message. Thresholds can be defined as a percentage (0-100), or nil.

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -62,7 +62,7 @@ module Teaspoon
     class Suite
       attr_accessor :matcher, :helper, :javascripts, :stylesheets,
                     :boot_partial, :body_partial,
-                    :no_coverage, :hooks, :expand_assets
+                    :hooks, :expand_assets
 
       def initialize(name = nil)
         @matcher       = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
@@ -73,7 +73,6 @@ module Teaspoon
         @boot_partial  = "boot"
         @body_partial  = "body"
 
-        @no_coverage   = [%r{/.rvm/gems/}, %r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
         @hooks         = Hash.new { |h, k| h[k] = [] }
         @expand_assets = true
 
@@ -97,6 +96,12 @@ module Teaspoon
       def hook(group = :default, &block)
         @hooks[group.to_s] << block
       end
+
+      def no_coverage(*)
+        Teaspoon.dep("suite.no_coverage has been removed in Teaspoon 1.0. Please use coverage.ignore instead. https://github.com/modeset/teaspoon/blob/master/CHANGELOG.md")
+        []
+      end
+      alias_method :no_coverage=, :no_coverage
     end
 
     # coverage configurations
@@ -109,12 +114,13 @@ module Teaspoon
     end
 
     class Coverage
-      attr_accessor :reports, :output_path,
+      attr_accessor :reports, :output_path, :ignore,
                     :statements, :functions, :branches, :lines
 
       def initialize
         @reports      = ["text-summary"]
         @output_path  = "coverage"
+        @ignore       = [%r{/.rvm/gems/}, %r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
 
         @statements   = nil
         @functions    = nil

--- a/lib/teaspoon/runner.rb
+++ b/lib/teaspoon/runner.rb
@@ -59,7 +59,7 @@ module Teaspoon
       raise Teaspoon::IstanbulNotFoundError unless Teaspoon::Instrumentation.executable
       return unless data.present?
 
-      coverage = Teaspoon::Coverage.new(@suite_name, Teaspoon.configuration.use_coverage, data)
+      coverage = Teaspoon::Coverage.new(@suite_name, data)
       coverage.generate_reports { |msg| notify_formatters("coverage", msg) }
       coverage.check_thresholds do |msg|
         notify_formatters("threshold_failure", msg)

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -13,7 +13,7 @@ module Teaspoon
     end
 
     attr_accessor :config, :name
-    delegate :helper, :stylesheets, :javascripts, :boot_partial, :body_partial, :no_coverage, :hooks,
+    delegate :helper, :stylesheets, :javascripts, :boot_partial, :body_partial, :hooks,
              to: :config
 
     def initialize(options = {})
@@ -31,21 +31,6 @@ module Teaspoon
       assets = specs
       assets.unshift(helper) if include_helper && helper
       asset_tree(assets)
-    end
-
-    def include_spec?(file)
-      glob.include?(file)
-    end
-
-    def ignored_file?(file)
-      for ignored in no_coverage
-        if ignored.is_a?(String)
-          return true if File.basename(file) == ignored
-        elsif ignored.is_a?(Regexp)
-          return true if file =~ ignored
-        end
-      end
-      false
     end
 
     def include_spec_for?(file)
@@ -82,8 +67,12 @@ module Teaspoon
 
     def instrument_file?(file)
       return false unless @options[:coverage] || Teaspoon.configuration.use_coverage
-      return false if include_spec?(file) || ignored_file?(file)
+      return false if matched_spec_file?(file)
       true
+    end
+
+    def matched_spec_file?(file)
+      glob.include?(file)
     end
 
     def asset_from_file(original)

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -108,9 +108,6 @@ describe Teaspoon::Configuration::Suite do
     expect(subject.helper).to eq("spec_helper")
     expect(subject.javascripts).to eq(["jasmine/1.3.1", "teaspoon/jasmine1"])
     expect(subject.stylesheets).to eq(["teaspoon"])
-    expect(subject.no_coverage).to eq([
-      %r{/.rvm/gems/}, %r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}
-    ])
     expect(subject.expand_assets).to eq(true)
   end
 
@@ -158,6 +155,16 @@ describe Teaspoon::Configuration::Suite do
       end
     end
   end
+
+  describe "deprecations" do
+    describe "no_coverage=" do
+      it "deprecates with no backwards compatibility" do
+        expect(Teaspoon).to receive(:dep).with("suite.no_coverage has been removed in Teaspoon 1.0. Please use coverage.ignore instead. https://github.com/modeset/teaspoon/blob/master/CHANGELOG.md")
+
+        subject.no_coverage = [/excluded.js/]
+      end
+    end
+  end
 end
 
 describe Teaspoon::Configuration::Coverage do
@@ -166,6 +173,9 @@ describe Teaspoon::Configuration::Coverage do
   it "has the default configuration" do
     expect(subject.reports).to eq(["text-summary"])
     expect(subject.output_path).to eq("coverage")
+    expect(subject.ignore).to eq([
+      %r{/.rvm/gems/}, %r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}
+    ])
     expect(subject.statements).to be_nil
     expect(subject.functions).to be_nil
     expect(subject.branches).to be_nil

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -90,6 +90,33 @@ describe Teaspoon::Instrumentation do
     it "doesn't if there's no asset" do
       expect(subject.add?([404, { "Content-Type" => "application/javascript" }, []], env)).to_not be(true)
     end
+
+    describe "with ignored files" do
+      def ignore(paths)
+        config = Teaspoon::Configuration::Coverage.new do |coverage|
+          coverage.ignore = paths
+        end
+        allow(Teaspoon::Coverage).to receive(:configuration).and_return(config)
+      end
+
+      it "doesn't include the file" do
+        ignore(["path/to"])
+
+        expect(subject.add?(response, "QUERY_STRING" => "instrument=true")).to be(false)
+      end
+
+      it "works with regular expressions" do
+        ignore([/path\/to/])
+
+        expect(subject.add?(response, "QUERY_STRING" => "instrument=true")).to be(false)
+      end
+
+      it "works if the files are not an array" do
+        ignore("path/to")
+
+        expect(subject.add?(response, "QUERY_STRING" => "instrument=true")).to be(false)
+      end
+    end
   end
 
   describe "integration" do

--- a/spec/teaspoon/runner_spec.rb
+++ b/spec/teaspoon/runner_spec.rb
@@ -84,8 +84,8 @@ describe Teaspoon::Runner do
       end
 
       it "resolves coverage" do
-        expect(Teaspoon.configuration).to receive(:use_coverage).twice.and_return("_config_")
-        expect(Teaspoon::Coverage).to receive(:new).with(:default, "_config_", "_coverage_").and_return(coverage)
+        expect(Teaspoon.configuration).to receive(:use_coverage).and_return("_config_")
+        expect(Teaspoon::Coverage).to receive(:new).with(:default, "_coverage_").and_return(coverage)
         expect(coverage).to receive(:generate_reports).and_yield("_generated_reports_")
         expect(coverage).to receive(:check_thresholds).and_yield("_threshold_failures_")
         expect(subject).to receive(:notify_formatters).once.with("coverage", "_generated_reports_")

--- a/spec/teaspoon/suite_spec.rb
+++ b/spec/teaspoon/suite_spec.rb
@@ -74,9 +74,11 @@ describe Teaspoon::Suite do
   end
 
   describe "#spec_assets" do
+    subject { described_class.new(coverage: true) }
+
     it "returns an array of assets" do
       result = subject.spec_assets
-      expect(result).to include("spec_helper.self.js?body=1")
+      expect(result).to include("spec_helper.self.js?body=1&instrument=1")
       expect(result).to include("teaspoon/reporters/console_spec.self.js?body=1")
     end
 
@@ -87,11 +89,11 @@ describe Teaspoon::Suite do
     end
 
     it "returns the asset tree (all dependencies resolved) if we want coverage" do
-      allow(subject).to receive(:no_coverage).and_return([%r{support/}, "spec_helper.coffee"])
-      subject.instance_variable_set(:@options, coverage: true)
       result = subject.spec_assets(true)
-      expect(result).to include("support/json2.self.js?body=1")
-      expect(result).to include("spec_helper.self.js?body=1")
+
+      expect(result).to include("teaspoon/reporters/console_spec.self.js?body=1") # Specs do not get instrumentation
+      expect(result).to include("support/json2.self.js?body=1&instrument=1")
+      expect(result).to include("spec_helper.self.js?body=1&instrument=1")
       expect(result).to include("driver/phantomjs/runner.self.js?body=1&instrument=1")
     end
 
@@ -99,13 +101,6 @@ describe Teaspoon::Suite do
       allow(subject.config).to receive(:expand_assets).and_return(false)
       result = subject.spec_assets(true)
       expect(result.any? { |file| file =~ /body=1/ }).to eq(false)
-    end
-  end
-
-  describe "#include_spec?" do
-    it "returns true if the spec was found in the suite" do
-      files = subject.send(:glob)
-      expect(subject.include_spec?(files.first)).to eq(true)
     end
   end
 


### PR DESCRIPTION
Since RequireJS does not use sprockets to require assets, 4ed7fbd was added to put instrumentation on all assets if coverage is requested. `suite.no_coverage` (removed) was used to exclude files from instrumentation as they are compiled in `suite.spec_assets` and included on the page for testing. Since `suite.no_coverage` was only being referenced when requiring assets from sprockets, it had no affect on people using RequireJS. #322 was proposed to ignore files for the case of RequireJS. This is a more formal stab at the same idea.

### Upgrade notes

Anyone doing:

```ruby
suite.no_coverage += /my_file.js/
```

Should now do:

```ruby
config.coverage do |coverage|
  coverage.ignore += /my_file.js/
end
```