### PR TITLE
Keep file filter around when grepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Unreleased
 
+#### Bug Fixes
+
+* Retain file filter when navigating to specs (#327)
+
+
 ### 1.0.2 (5/5/15)
 
 #### Bug Fixes

--- a/app/assets/javascripts/teaspoon/mixins/_namespace.coffee
+++ b/app/assets/javascripts/teaspoon/mixins/_namespace.coffee
@@ -1,0 +1,1 @@
+Teaspoon.Mixins ||= {}

--- a/app/assets/javascripts/teaspoon/mixins/filter_url.coffee
+++ b/app/assets/javascripts/teaspoon/mixins/filter_url.coffee
@@ -1,0 +1,6 @@
+Teaspoon.Mixins.FilterUrl =
+  filterUrl: (grep) ->
+    params = []
+    params.push("grep=#{encodeURIComponent(grep)}")
+    params.push("file=#{Teaspoon.params.file}") if Teaspoon.params.file
+    "?#{params.join("&")}"

--- a/app/assets/javascripts/teaspoon/spec.coffee
+++ b/app/assets/javascripts/teaspoon/spec.coffee
@@ -1,0 +1,2 @@
+class Teaspoon.Spec
+  Teaspoon.Utility.include(@, Teaspoon.Mixins.FilterUrl)

--- a/app/assets/javascripts/teaspoon/suite.coffee
+++ b/app/assets/javascripts/teaspoon/suite.coffee
@@ -1,0 +1,2 @@
+class Teaspoon.Suite
+  Teaspoon.Utility.include(@, Teaspoon.Mixins.FilterUrl)

--- a/app/assets/javascripts/teaspoon/teaspoon.coffee
+++ b/app/assets/javascripts/teaspoon/teaspoon.coffee
@@ -1,7 +1,11 @@
 #= require_self
+#= require_tree ./mixins
+#= require teaspoon/utility
 #= require teaspoon/runner
 #= require teaspoon/fixture
 #= require teaspoon/hook
+#= require teaspoon/spec
+#= require teaspoon/suite
 #= require teaspoon/reporters/html
 #= require teaspoon/reporters/console
 

--- a/app/assets/javascripts/teaspoon/utility.coffee
+++ b/app/assets/javascripts/teaspoon/utility.coffee
@@ -1,0 +1,7 @@
+class Teaspoon.Utility
+  @extend: (obj, mixin) ->
+    obj[name] = method for name, method of mixin
+    obj
+
+  @include: (klass, mixin) ->
+    @extend(klass.prototype, mixin)

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine1/spec.coffee
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine1/spec.coffee
@@ -1,9 +1,9 @@
-class Teaspoon.Jasmine1.Spec
+class Teaspoon.Jasmine1.Spec extends Teaspoon.Spec
 
   constructor: (@spec) ->
     @fullDescription = @spec.getFullName()
     @description = @spec.description
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = @spec.suite
     @suiteName = @parent.getFullName()
     @viewId = @spec.viewId

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine1/suite.coffee
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine1/suite.coffee
@@ -1,8 +1,8 @@
-class Teaspoon.Jasmine1.Suite
+class Teaspoon.Jasmine1.Suite extends Teaspoon.Suite
 
   constructor: (@suite) ->
     @fullDescription = @suite.getFullName()
     @description = @suite.description
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = @suite.parentSuite
     @viewId = @suite.viewId

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/spec.coffee
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/spec.coffee
@@ -1,9 +1,9 @@
-class Teaspoon.Jasmine2.Spec
+class Teaspoon.Jasmine2.Spec extends Teaspoon.Spec
 
   constructor: (@spec) ->
     @fullDescription = @spec.fullName
     @description = @spec.description
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = @spec.parent
     @suiteName = @parent.fullName
     @viewId = @spec.id

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/suite.coffee
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/suite.coffee
@@ -1,8 +1,8 @@
-class Teaspoon.Jasmine2.Suite
+class Teaspoon.Jasmine2.Suite extends Teaspoon.Suite
 
   constructor: (@suite) ->
     @fullDescription = @suite.fullName
     @description = @suite.description
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = @suite.parent
     @viewId = @suite.id

--- a/teaspoon-jasmine/spec/javascripts/jasmine1/spec_spec.coffee
+++ b/teaspoon-jasmine/spec/javascripts/jasmine1/spec_spec.coffee
@@ -22,14 +22,19 @@ describe "Teaspoon.Jasmine1.Spec", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       spec = new Teaspoon.Jasmine1.Spec(@mockSpec)
       expect(spec.fullDescription).toBe("_full jasmine description_")
       expect(spec.description).toBe("_jasmine_description_")
-      expect(spec.link).toBe("?grep=_full%20jasmine%20description_")
+      expect(spec.link).toBe("?grep=_full%20jasmine%20description_&file=spec.js")
       expect(spec.parent).toBe(@mockSuite)
       expect(spec.suiteName).toBe("_full jasmine name_")
       expect(spec.viewId).toBe(42)
       expect(spec.pending).toBe(false)
+
+      Teaspoon.params = originalParams
 
 
   describe "#errors", ->

--- a/teaspoon-jasmine/spec/javascripts/jasmine1/suite_spec.coffee
+++ b/teaspoon-jasmine/spec/javascripts/jasmine1/suite_spec.coffee
@@ -11,9 +11,14 @@ describe "Teaspoon.Jasmine1.Suite", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       suite = new Teaspoon.Jasmine1.Suite(@mockSuite)
       expect(suite.fullDescription).toBe("_full jasmine description_")
       expect(suite.description).toBe("_jasmine_description_")
-      expect(suite.link).toBe("?grep=_full%20jasmine%20description_")
+      expect(suite.link).toBe("?grep=_full%20jasmine%20description_&file=spec.js")
       expect(suite.parent).toBe(@mockParentSuite)
       expect(suite.viewId).toBe(42)
+
+      Teaspoon.params = originalParams

--- a/teaspoon-jasmine/spec/javascripts/jasmine2/spec_spec.coffee
+++ b/teaspoon-jasmine/spec/javascripts/jasmine2/spec_spec.coffee
@@ -21,14 +21,19 @@ describe "Teaspoon.Jasmine2.Spec", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       spec = new Teaspoon.Jasmine2.Spec(@mockSpec, @mockSuite)
       expect(spec.fullDescription).toBe("_full jasmine description_")
       expect(spec.description).toBe("_jasmine_description_")
-      expect(spec.link).toBe("?grep=_full%20jasmine%20description_")
+      expect(spec.link).toBe("?grep=_full%20jasmine%20description_&file=spec.js")
       expect(spec.parent).toBe(@mockSuite)
       expect(spec.suiteName).toBe("_full jasmine name_")
       expect(spec.viewId).toBe("42")
       expect(spec.pending).toBe(false)
+
+      Teaspoon.params = originalParams
 
 
   describe "#errors", ->

--- a/teaspoon-jasmine/spec/javascripts/jasmine2/suite_spec.coffee
+++ b/teaspoon-jasmine/spec/javascripts/jasmine2/suite_spec.coffee
@@ -13,9 +13,14 @@ describe "Teaspoon.Jasmine2.Suite", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       suite = new Teaspoon.Jasmine2.Suite(@mockSuite)
       expect(suite.fullDescription).toBe("_full jasmine description_")
       expect(suite.description).toBe("_jasmine_description_")
-      expect(suite.link).toBe("?grep=_full%20jasmine%20description_")
+      expect(suite.link).toBe("?grep=_full%20jasmine%20description_&file=spec.js")
       expect(suite.parent).toBe(@mockParentSuite)
       expect(suite.viewId).toBe("42")
+
+      Teaspoon.params = originalParams

--- a/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon/mocha/spec.coffee
+++ b/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon/mocha/spec.coffee
@@ -1,9 +1,9 @@
-class Teaspoon.Mocha.Spec
+class Teaspoon.Mocha.Spec extends Teaspoon.Spec
 
   constructor: (@spec) ->
     @fullDescription = @spec.fullTitle()
     @description = @spec.title
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = @spec.parent
     @suiteName = @parent.fullTitle()
     @viewId = @spec.viewId

--- a/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon/mocha/suite.coffee
+++ b/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon/mocha/suite.coffee
@@ -1,8 +1,8 @@
-class Teaspoon.Mocha.Suite
+class Teaspoon.Mocha.Suite extends Teaspoon.Suite
 
   constructor: (@suite) ->
     @fullDescription = @suite.fullTitle()
     @description = @suite.title
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = if @suite.parent?.root then null else @suite.parent
     @viewId = @suite.viewId

--- a/teaspoon-mocha/spec/javascripts/mocha/spec_spec.coffee
+++ b/teaspoon-mocha/spec/javascripts/mocha/spec_spec.coffee
@@ -17,14 +17,19 @@ describe "Teaspoon.Mocha.Spec", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       spec = new Teaspoon.Mocha.Spec(@mockSpec)
       expect(spec.fullDescription).to.be("_full mocha description_")
       expect(spec.description).to.be("_mocha_description_")
-      expect(spec.link).to.be("?grep=_full%20mocha%20description_")
+      expect(spec.link).to.be("?grep=_full%20mocha%20description_&file=spec.js")
       expect(spec.parent).to.be(@mockSuite)
       expect(spec.suiteName).to.be("_full mocha name_")
       expect(spec.viewId).to.be(420)
       expect(spec.pending).to.be(false)
+
+      Teaspoon.params = originalParams
 
 
   describe "#errors", ->

--- a/teaspoon-mocha/spec/javascripts/mocha/suite_spec.coffee
+++ b/teaspoon-mocha/spec/javascripts/mocha/suite_spec.coffee
@@ -11,9 +11,14 @@ describe "Teaspoon.Mocha.Suite", ->
   describe "constructor", ->
 
     it "has the expected properties", ->
+      originalParams = Teaspoon.params
+      Teaspoon.params.file = "spec.js"
+
       suite = new Teaspoon.Mocha.Suite(@mockSuite)
       expect(suite.fullDescription).to.be("_full mocha description_")
       expect(suite.description).to.be("_mocha_description_")
-      expect(suite.link).to.be("?grep=_full%20mocha%20description_")
+      expect(suite.link).to.be("?grep=_full%20mocha%20description_&file=spec.js")
       expect(suite.parent).to.be(@mockParentSuite)
       expect(suite.viewId).to.be(420)
+
+      Teaspoon.params = originalParams

--- a/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon/qunit/spec.coffee
+++ b/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon/qunit/spec.coffee
@@ -1,9 +1,9 @@
-class Teaspoon.Qunit.Spec
+class Teaspoon.Qunit.Spec extends Teaspoon.Spec
 
   constructor: (@spec) ->
     @fullDescription = "#{@spec.module} #{@spec.name}"
     @description = "#{@spec.name} (#{@spec.failed}, #{@spec.passed}, #{@spec.total})"
-    @link = "?grep=#{encodeURIComponent("#{@spec.module}: #{@spec.name}")}"
+    @link = @filterUrl("#{@spec.module}: #{@spec.name}")
     @parent = if @spec.module then new Teaspoon.Qunit.Suite({description: @spec.module}) else null
     @suiteName = @spec.module
     @viewId = @spec.viewId

--- a/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon/qunit/suite.coffee
+++ b/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon/qunit/suite.coffee
@@ -1,16 +1,9 @@
-class Teaspoon.Qunit.Suite
+class Teaspoon.Qunit.Suite extends Teaspoon.Suite
 
   constructor: (@suite) ->
     # In QUnit 1.14, moduleStart uses @suite.name,
     # moduleDone uses @suite.description
     @fullDescription = @suite.description || @suite.name
     @description = @suite.description || @suite.name
-    @link = "?grep=#{encodeURIComponent(@fullDescription)}"
+    @link = @filterUrl(@fullDescription)
     @parent = null
-
-
-# Shim since HTML.SuiteView still initializes the base class.
-# TODO: inject instance into SuiteView
-class Teaspoon.Suite
-  constructor: (suite) ->
-    return new Teaspoon.Qunit.Suite(suite)

--- a/teaspoon-qunit/test/javascripts/qunit/spec_test.coffee
+++ b/teaspoon-qunit/test/javascripts/qunit/spec_test.coffee
@@ -16,14 +16,19 @@ module "Teaspoon.Qunit.Spec",
       assertions: @mockAssertions
 
 test "constructor", 7, ->
+  originalParams = Teaspoon.params
+  Teaspoon.params.file = "spec.js"
+
   spec = new Teaspoon.Qunit.Spec(@mockSpec)
   ok(spec.fullDescription == "_full qunit name_ _description_", "sets fullDescription")
   ok(spec.description == "_description_ (1, 2, 3)", "sets description")
-  ok(spec.link == "?grep=_full%20qunit%20name_%3A%20_description_", "sets link")
+  ok(spec.link == "?grep=_full%20qunit%20name_%3A%20_description_&file=spec.js", "sets link")
   ok(spec.parent.description == "_full qunit name_", "builds a parent suite")
   ok(spec.suiteName == "_full qunit name_", "sets suiteName")
   ok(spec.viewId == 420, "sets viewId")
   ok(spec.pending == false, "sets pending to false") # no pending support
+
+  Teaspoon.params = originalParams
 
 test "#errors", 5, ->
   errors = new Teaspoon.Qunit.Spec(@mockSpec).errors()

--- a/teaspoon-qunit/test/javascripts/qunit/suite_test.coffee
+++ b/teaspoon-qunit/test/javascripts/qunit/suite_test.coffee
@@ -3,8 +3,13 @@ module "Teaspoon.Qunit.Suite",
     @mockSuite = description: "_full qunit description_"
 
 test "constructor", 4, ->
+  originalParams = Teaspoon.params
+  Teaspoon.params.file = "spec.js"
+
   suite = new Teaspoon.Qunit.Suite(@mockSuite)
   ok(suite.fullDescription == "_full qunit description_", "sets fullDescription")
   ok(suite.description == "_full qunit description_", "sets description")
-  ok(suite.link == "?grep=_full%20qunit%20description_", "sets link")
+  ok(suite.link == "?grep=_full%20qunit%20description_&file=spec.js", "sets link")
   ok(suite.parent == null, "sets parent to null") # no structure to consider
+
+  Teaspoon.params = originalParams


### PR DESCRIPTION
Fixes #327 

This PR does the following:

- Establishes a mixin pattern.
- Creates `Spec` and `Suite` base classes.
- Utilizes the mixin pattern and base classes to provide URL generation that retains the file filter.