### PR TITLE
Write Istanbul result to stdout when the coverage report errors

### DIFF
--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -56,7 +56,7 @@ module Teaspoon
       output_path = File.join(@config.output_path, @suite_name)
       result = %x{#{@executable} report --include=#{input.shellescape} --dir #{output_path} #{format} 2>&1}
       return result.gsub("Done", "").gsub("Using reporter [#{format}]", "").strip if $?.exitstatus == 0
-      raise Teaspoon::DependencyError.new("Unable to generate #{format} coverage report.")
+      raise Teaspoon::DependencyError.new("Unable to generate #{format} coverage report:\n#{result}")
     end
 
     def threshold_args

--- a/spec/teaspoon/coverage_spec.rb
+++ b/spec/teaspoon/coverage_spec.rb
@@ -64,7 +64,7 @@ describe Teaspoon::Coverage do
       stub_exit_code(ExitCodes::EXCEPTION)
       expect { subject.generate_reports }.to raise_error(
         Teaspoon::DependencyError,
-        "Unable to generate html coverage report."
+        /Unable to generate html coverage report/
       )
     end
   end


### PR DESCRIPTION
When Istanbul fails, it helps immensely to have the error that it reports. Having it would have helped me avoid a lot of confusion while trying to get coverage reports set up on Jenkins (Istanbul choked on the name of the Jenkins job). I thought about making this a flaggable option, but it seemed too specific for something general like `--[no-]debug`.