### PR TITLE
If the standard rails config/environment isn’t there...

### DIFF
--- a/lib/teaspoon/environment.rb
+++ b/lib/teaspoon/environment.rb
@@ -53,7 +53,14 @@ module Teaspoon
 
     def self.load_rails
       rails_env = ENV["TEASPOON_RAILS_ENV"] || File.expand_path("config/environment", Dir.pwd)
-      require rails_env
+
+      # Try to load rails, assume teaspoon_env will do it if the expected
+      # environment isn't found.
+      if File.exists?(rails_env)
+        require rails_env
+      else
+        require_environment
+      end
     end
   end
 end

--- a/spec/teaspoon/environment_spec.rb
+++ b/spec/teaspoon/environment_spec.rb
@@ -24,6 +24,13 @@ describe Teaspoon::Environment do
       described_class.load
     end
 
+    it "falls back to loading the teaspoon environment" do
+      allow(subject).to receive(:load_rails).and_call_original
+      allow(File).to receive(:exists?).and_return(false)
+      expect(subject).to receive(:require_environment)
+      described_class.load
+    end
+
     it "aborts if Rails can't be found" do
       expect(subject).to receive(:rails_loaded?).and_return(false)
       expect(Teaspoon).to receive(:abort).with("Rails environment not found.", 1)


### PR DESCRIPTION
Assume the teaspoon_env will handle loading rails (and avoiding double configuration). fixes #371

This allows alternate rails setups where there isn't a `config/environment.rb` file in your "rails" application.

Here's a [wiki article](https://github.com/modeset/teaspoon/wiki/Micro-Applications) that describes the process.