### PR TITLE
Fix try/catch on Jasmine 2 so that it works again

### DIFF
--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/reporters/html.coffee
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon/jasmine2/reporters/html.coffee
@@ -4,7 +4,7 @@ class Teaspoon.Jasmine2.Reporters.HTML extends Teaspoon.Reporters.HTML
 
   readConfig: ->
     super
-    jasmine.CATCH_EXCEPTIONS = @config["use-catch"]
+    jasmine.getEnv().catchExceptions(@config["use-catch"])
 
 
   envInfo: ->

--- a/teaspoon-jasmine/spec/javascripts/jasmine2/reporters/html_spec.coffee
+++ b/teaspoon-jasmine/spec/javascripts/jasmine2/reporters/html_spec.coffee
@@ -8,8 +8,7 @@ describe "Teaspoon.Jasmine2.Reporters.HTML", ->
 
     it "sets jasmine.CATCH_EXCEPTIONS", ->
       @reporter.readConfig()
-      expect(jasmine.CATCH_EXCEPTIONS).toBe(@reporter.config["use-catch"])
-
+      expect(jasmine.getEnv().catchingExceptions()).toBe(@reporter.config["use-catch"])
 
   describe "#envInfo", ->
 


### PR DESCRIPTION
In Jasmine 1, you can toggle whether Jasmine catches exceptions by
setting `Jasmine.CATCH_EXCEPTIONS`.

In Jasmine 2, this option [has moved] to the `jasmine.Env` object, and
instead of setting a property, you call the function `catchExceptions`.

[has moved]: https://github.com/jasmine/jasmine/blob/v2.3.4/src/core/Env.js#L138