### PR TITLE
Removed test_files from gemspec

### DIFF
--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files       = Dir["{app,lib,bin}/**/*"] + ["MIT.LICENSE", "README.md", "CHANGELOG.md"]
-  s.test_files  = `git ls-files -- {spec}/*`.split("\n")
   s.executables = ["teaspoon"]
 
   s.add_dependency "railties", [">= 3.2.5", "< 5"]


### PR DESCRIPTION
I was just looking through the code installed for teaspoon, and I noticed that the /spec/dummy directory is huge. It turns out that rubygems is packaging up not only /spec/dummy, but also all the tempfiles and logfiles there *at the time of packaging*.

The latest consensus is that test_files shouldn't be packaged with a gem anyway (see https://github.com/bundler/bundler/pull/3207) because they're never used, so rather than filtering out /spec/dummy/log and /spec/dummy/tmp I've prevented rubygems from packing test files at all.