### PR TITLE
Support $.parseHtml for more robust fixtures

### DIFF
--- a/app/assets/javascripts/teaspoon/fixture.coffee
+++ b/app/assets/javascripts/teaspoon/fixture.coffee
@@ -63,18 +63,22 @@ class Teaspoon.Fixture
 
   putContent = (content) =>
     cleanup()
-    create()
-    window.fixture.el.innerHTML = content
+    addContent(content)
 
 
   addContent = (content) =>
     create() unless window.fixture.el
-    window.fixture.el.innerHTML += content
+
+    if jQueryAvailable()
+      parsed = $($.parseHTML(content, document, true))
+      window.fixture.el.appendChild(parsed[i]) for i in [0...parsed.length]
+    else
+      window.fixture.el.innerHTML += content
 
 
   create = =>
     window.fixture.el = document.createElement("div")
-    window.fixture.$el = $(window.fixture.el) if typeof(window.$) == 'function'
+    window.fixture.$el = $(window.fixture.el) if jQueryAvailable()
     window.fixture.el.id = "teaspoon-fixtures"
     document.body?.appendChild(window.fixture.el)
 
@@ -98,3 +102,7 @@ class Teaspoon.Fixture
     xhr.onreadystatechange = callback
     xhr.open("GET", "#{Teaspoon.root}/fixtures/#{url}", false)
     xhr.send()
+
+
+  jQueryAvailable = ->
+    typeof(window.$) == 'function'

--- a/spec/javascripts/spec_helper.coffee
+++ b/spec/javascripts/spec_helper.coffee
@@ -1,4 +1,5 @@
 #= require support/json2
+#= require jquery
 
 window.passing = true
 window.failing = false

--- a/spec/javascripts/teaspoon/fixture_spec.coffee
+++ b/spec/javascripts/teaspoon/fixture_spec.coffee
@@ -78,6 +78,24 @@ describe "Teaspoon.Fixture", ->
       fixture.set("_content3_", false)
       expect(document.getElementById("teaspoon-fixtures").innerHTML).toBe("_content3_")
 
+    it "supports invalid HTML", ->
+      fixture.set("<td>Row</td>")
+      expect(document.getElementById("teaspoon-fixtures").innerHTML).toBe("<td>Row</td>")
+
+    describe "without jQuery", ->
+      jQ = null
+
+      beforeEach ->
+        jQ = window.$
+        window.$ = undefined
+
+      afterEach ->
+        window.$ = jQ
+
+      it "does not support invalid HTML", ->
+        fixture.set("<td>Row</td>")
+        expect(document.getElementById("teaspoon-fixtures").innerHTML).toBe("Row")
+
 
   describe "@preload", ->
 


### PR DESCRIPTION
Support broken HTML with `$.parseHtml`. Can't really write a good test for this since Teaspoon doesn't ship with jQuery, but here is the test I built against, which fails without jQuery:

```javascript
it "supports invalid HTML", ->
  fixture.set("<td>Row</td>")
  expect(document.getElementById("teaspoon-fixtures").innerHTML).toBe("<td>Row</td>")
```

Fixes #387 
Fixes #382