### PR TITLE
Support .js.jsx.coffee file extension in Teaspoon::Suite

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -95,7 +95,7 @@ module Teaspoon
     end
 
     def normalize_js_extension(filename)
-      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6)$/, ".js")
+      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6|\.js\.jsx\.coffee)$/, ".js")
     end
 
     def glob

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -95,7 +95,7 @@ module Teaspoon
     end
 
     def normalize_js_extension(filename)
-      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6|\.js\.jsx\.coffee)$/, ".js")
+      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6|\.js\.jsx(?:\.coffee)?)$/, ".js")
     end
 
     def glob


### PR DESCRIPTION
We are writing specs for React components. We are using the .js.jsx.coffee file extension so we can use jsx in our specs.

When we try to view these files in our suite by browsing to /teaspoon, the files show up as filename.js.jsx.js. Updating `normalize_js_extension` causes the files to show up correctly when viewing the files at /teaspoon.

Is this the preferred way of supporting new file extensions?