### PR TITLE
Deprecates suite.use_framework=

### DIFF
--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -93,7 +93,10 @@ module Teaspoon
 
         raise Teaspoon::UnknownFrameworkVersion.new(name: name, version: version)
       end
-      alias_method :use_framework=, :use_framework
+
+      def use_framework=(name, version = nil)
+        use_framework(*name)
+      end
 
       def hook(group = :default, &block)
         @hooks[group.to_s] << block

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -94,10 +94,6 @@ module Teaspoon
         raise Teaspoon::UnknownFrameworkVersion.new(name: name, version: version)
       end
 
-      def use_framework=(name, version = nil)
-        use_framework(*name)
-      end
-
       def hook(group = :default, &block)
         @hooks[group.to_s] << block
       end

--- a/lib/teaspoon/deprecated.rb
+++ b/lib/teaspoon/deprecated.rb
@@ -84,7 +84,7 @@ teaspoon coverage directive has changed and is now more flexible, define coverag
       end
       alias_method :no_coverage=, :no_coverage
 
-      def use_framework=(name, version = nil)
+      def use_framework=(name, _version = nil)
         Teaspoon.dep("suite.use_framework= is deprecated, use suite.use_framework instead.")
         use_framework(*name)
       end

--- a/lib/teaspoon/deprecated.rb
+++ b/lib/teaspoon/deprecated.rb
@@ -83,6 +83,11 @@ teaspoon coverage directive has changed and is now more flexible, define coverag
         []
       end
       alias_method :no_coverage=, :no_coverage
+
+      def use_framework=(name, version = nil)
+        Teaspoon.dep("suite.use_framework= is deprecated, use suite.use_framework instead.")
+        use_framework(*name)
+      end
     end
   end
 end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -170,6 +170,14 @@ describe Teaspoon::Configuration::Suite do
         subject.no_coverage = [/excluded.js/]
       end
     end
+
+    describe "use_framework=" do
+      it "deprecates with no backwards compatibility" do
+        expect(Teaspoon).to receive(:dep).with("suite.use_framework= is deprecated, use suite.use_framework instead.")
+
+        subject.use_framework = :jasmine, "1.3.1"
+      end
+    end
   end
 end
 

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -129,6 +129,12 @@ describe Teaspoon::Configuration::Suite do
       expect(subject.javascripts[1]).to match(/teaspoon[-|\/]mocha\.js/)
     end
 
+    it "allows specifying framework with a version using use_framework=" do
+      @suite = proc { |s| s.use_framework = :mocha, "1.10.0" }
+      expect(subject.javascripts[0]).to match(/mocha\/\d+\.\d+\.\d+\.js/)
+      expect(subject.javascripts[1]).to match(/teaspoon[-|\/]mocha\.js/)
+    end
+
     it "handles qunit specifically to set matcher and helper" do
       @suite = proc { |s| s.use_framework :qunit }
       expect(subject.javascripts[0]).to match(/qunit\/\d+\.\d+\.\d+\.js/)


### PR DESCRIPTION
This bit me today and I yak shaved for a couple of hours. In my config, I had the following:

``` ruby
config.suite do |suite|
  suite.use_framework = :jasmine, "1.3.1"
end
```

Teaspoon accepted the configuration except every time I ran the rake task, it would raise an exception:

``` ruby
Teaspoon::UnknownFramework: Teaspoon::UnknownFramework
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/registry.rb:24:in `fetch'
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/configuration.rb:88:in `use_framework'
/home/v/code/spec/javascripts/config.rb:6:in `block (2 levels) in <top (required)>'
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/configuration.rb:82:in `initialize'
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/configuration.rb:59:in `new'
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/configuration.rb:59:in `suite'
/home/v/code/spec/javascripts/config.rb:5:in `block in <top (required)>'
/home/v/.gem/ruby/2.2.2/gems/teaspoon-1.0.2/lib/teaspoon/configuration.rb:167:in `configure'
/home/v/code/spec/javascripts/config.rb:1:in `<top (required)>'
```

A bit of debugging revealed this:

``` ruby
[1] pry(main)> class Test
[1] pry(main)*   def use(one, two = nil)
[1] pry(main)*     puts "one #{one}"
[1] pry(main)*     puts "two #{two}"
[1] pry(main)*   end
[1] pry(main)*   alias_method :use=, :use
[1] pry(main)* end
=> Test
[2] pry(main)> test = Test.new
=> #<Test:0x007f92b6ee8ea0>
[3] pry(main)> test.use = :jasmine, '1.3.1'
one [:jasmine, "1.3.1"]
two
=> [:jasmine, "1.3.1"]
[4] pry(main)> test.use = :jasmine
one jasmine
two
=> :jasmine
[5] pry(main)> test.use(:jasmine, '1.3.1')
one jasmine
two 1.3.1
=> nil
```

The only time the `use_framework=` method works is when you pass in a single argument (framework name). Is this method worth keeping around?