### PR TITLE
Add .es6.js to normalize_js_extension

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -95,7 +95,7 @@ module Teaspoon
     end
 
     def normalize_js_extension(filename)
-      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6)$/, ".js")
+      filename.gsub(".erb", "").gsub(/(\.js\.coffee|\.coffee|\.es6|\.js\.es6|\.es6\.js)$/, ".js")
     end
 
     def glob


### PR DESCRIPTION
@jejacks0n @mikepack 

Some people use this as an extension for es6 files.

This might be better off as a configuration parameter, or alternatively you could look at `Sprockets.mime_types["text/ecmascript-6"]` to find out which extensions are registered to that mime type