### PR TITLE
Removed outdated css prefixes

### DIFF
--- a/app/assets/stylesheets/teaspoon.css
+++ b/app/assets/stylesheets/teaspoon.css
@@ -117,13 +117,7 @@ html[xmlns] #teaspoon-interface .teaspoon-clearfix {
   width: 87px;
   height: 34px;
   -webkit-transform: rotate(-18deg);
-  -moz-transform: rotate(-18deg);
   transform: rotate(-18deg);
-  background: -moz-linear-gradient(top, rgba(255, 255, 255,0) 0%, rgba(255, 255, 255, 0.3) 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, rgba(255, 255, 255, 0)), color-stop(100%, rgba(255, 255, 255, 0.3)));
-  background: -webkit-linear-gradient(top, rgba(255,255,255,0) 0%, rgba(255, 255, 255, 0.3) 100%);
-  background: -o-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.3) 100%);
-  background: -ms-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.3) 100%);
   background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.3) 100%);
   content: "\00a0";
 }
@@ -176,21 +170,13 @@ html[xmlns] #teaspoon-interface .teaspoon-clearfix {
   outline: none;
   border-radius: 0.4em;
   background-color: #fff;
-  background-image: -webkit-linear-gradient(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.05));
-  background-image: -moz-linear-gradient(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.05));
-  background-image: -o-linear-gradient(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.05));
-  background-image: -ms-linear-gradient(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.05));
   background-image: linear-gradient(rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.05));
-  -webkit-box-shadow: inset 0 1px 4px rgba(255, 255, 255, 0.5);
-  -moz-box-shadow: inset 0 1px 4px rgba(255, 255, 255, 0.5);
   box-shadow: inset 0 1px 4px rgba(255, 255, 255, 0.5);
   text-align: center;
   cursor: pointer;
 }
 #teaspoon-controls button:active,
 #teaspoon-controls button.active {
-  -webkit-box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
-  -moz-box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
   background: #D9D9D9;
   outline: 0;


### PR DESCRIPTION
I use [autoprefixer](https://github.com/postcss/autoprefixer) in my rails project (it automatically adds vendor specific prefixes to css rules when necessary). However, it's reporting that some of the css in teaspoon is using invalid css for linear gradients:

```
autoprefixer: /Users/iain/.gem/ruby/2.2.3/gems/teaspoon-1.0.2/app/assets/stylesheets/teaspoon.css:124:3: Gradient has outdated direction syntax. New syntax is like "to left" instead of "right".
```

Rather than correct the syntax for gradients, instead I've removed all css vendor prefixes that are no longer required by current browsers, based on [caniuse](http://caniuse.com). The only prefixed rule left is `-webkit-transform`, as apparently current versions of safari (version 8.x) still require the prefix.