### PR TITLE
Add an option to specify the server host

### DIFF
--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -113,6 +113,9 @@ Teaspoon.configure do |config|
   # Specify a server to use with Rack (e.g. thin, mongrel). If nil is provided Rack::Server is used.
   #config.server = nil
 
+  # Specify a host to run on a specific host, otherwise Teaspoon will use 127.0.0.1.
+  #config.server_host = nil
+
   # Specify a port to run on a specific port, otherwise Teaspoon will use a random available port.
   #config.server_port = nil
 

--- a/lib/teaspoon/command_line.rb
+++ b/lib/teaspoon/command_line.rb
@@ -56,6 +56,9 @@ module Teaspoon
           "Sets server to use with Rack.",
           "  e.g. webrick, thin"
 
+      opt :server_host, "--server-host HOST",
+          "Sets the server to use a specific host."
+
       opt :server_port, "--server-port PORT",
           "Sets the server to use a specific port."
 

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -25,13 +25,14 @@ module Teaspoon
 
     # console runner specific
 
-    cattr_accessor :driver, :driver_options, :driver_timeout, :server, :server_port, :server_timeout, :fail_fast,
+    cattr_accessor :driver, :driver_options, :driver_timeout, :server, :server_host, :server_port, :server_timeout, :fail_fast,
                    :formatters, :color, :suppress_log,
                    :use_coverage
     @@driver         = Teaspoon::Driver.default
     @@driver_options = nil
     @@driver_timeout = 180
     @@server         = nil
+    @@server_host    = nil
     @@server_port    = nil
     @@server_timeout = 20
     @@fail_fast      = true

--- a/lib/teaspoon/server.rb
+++ b/lib/teaspoon/server.rb
@@ -4,9 +4,10 @@ require "webrick"
 
 module Teaspoon
   class Server
-    attr_accessor :port
+    attr_accessor :port, :host
 
     def initialize
+      @host = Teaspoon.configuration.server_host || "127.0.0.1"
       @port = Teaspoon.configuration.server_port || find_available_port
     end
 
@@ -24,14 +25,14 @@ module Teaspoon
     end
 
     def responsive?
-      TCPSocket.new("127.0.0.1", port).close
+      TCPSocket.new(host, port).close
       true
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
       false
     end
 
     def url
-      "http://127.0.0.1:#{port}"
+      "http://#{host}:#{port}"
     end
 
     protected
@@ -54,6 +55,7 @@ module Teaspoon
     def rack_options
       {
         app: Rails.application,
+        Host: host,
         Port: port,
         environment: "test",
         AccessLog: [],
@@ -63,7 +65,7 @@ module Teaspoon
     end
 
     def find_available_port
-      server = TCPServer.new("127.0.0.1", 0)
+      server = TCPServer.new(host, 0)
       server.addr[1]
     ensure
       server.close if server

--- a/spec/teaspoon/command_line_spec.rb
+++ b/spec/teaspoon/command_line_spec.rb
@@ -66,6 +66,7 @@ describe Teaspoon::CommandLine do
               --driver-timeout SECONDS     Sets the timeout for the driver to wait before exiting.
               --server SERVER              Sets server to use with Rack.
                                              e.g. webrick, thin
+              --server-host HOST           Sets the server to use a specific host.
               --server-port PORT           Sets the server to use a specific port.
               --server-timeout SECONDS     Sets the timeout that the server must start within.
           -F, --[no-]fail-fast             Abort after the first failing suite.
@@ -107,6 +108,7 @@ describe Teaspoon::CommandLine do
         driver_options: ["driver-options", "_driver_options_"],
         driver_timeout: ["driver-timeout", "_driver_timeout_"],
         server: ["server", "_server_"],
+        server_host: ["server-host", "_server_host_"],
         server_port: ["server-port", "_server_port_"],
         server_timeout: ["server-timeout", "_server_timeout_"],
         suite: ["suite", "_suite_"],

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -29,6 +29,7 @@ describe Teaspoon::Configuration do
     expect(subject.driver_options).to be_nil
     expect(subject.driver_timeout).to eq(180)
     expect(subject.server).to be_nil
+    expect(subject.server_host).to be_nil
     expect(subject.server_port).to be_nil
     expect(subject.server_timeout).to eq(20)
     expect(subject.formatters).to eq([:dot])

--- a/spec/teaspoon/server_spec.rb
+++ b/spec/teaspoon/server_spec.rb
@@ -44,6 +44,7 @@ describe Teaspoon::Server do
     it "creates a Rack::Server with the correct setting" do
       expected_opts = {
         app: Rails.application,
+        Host: subject.host,
         Port: subject.port,
         environment: "test",
         AccessLog: [],
@@ -76,12 +77,26 @@ describe Teaspoon::Server do
       expect(socket).to receive(:close)
       subject.responsive?
     end
+
+    it "checks a port in a given host to see if a server is running" do
+      subject.host = "0.0.0.0"
+      subject.port = 31337
+      expect(TCPSocket).to receive(:new).with("0.0.0.0", 31337).and_return(socket)
+      expect(socket).to receive(:close)
+      subject.responsive?
+    end
   end
 
   describe "#url" do
     it "returns a url for the server that includes the port" do
       subject.port = 31337
       expect(subject.url).to eq("http://127.0.0.1:31337")
+    end
+
+    it "returns a url for the server that includes the host" do
+      subject.host = "0.0.0.0"
+      subject.port = 31337
+      expect(subject.url).to eq("http://0.0.0.0:31337")
     end
   end
 


### PR DESCRIPTION
By default teaspoon starts the server on localhost interface. This
breaks some setup that use different hosts like vagrant.

We are introducing a new option so the server host can be changed.

Closes #397.

cc @mikepack