### PR TITLE
Fix base formatter when there are no params on the filename

### DIFF
--- a/lib/teaspoon/formatter/base.rb
+++ b/lib/teaspoon/formatter/base.rb
@@ -145,8 +145,13 @@ module Teaspoon
 
       def filename(file)
         uri = URI(file)
-        params = uri.query.split("&").reject do |param|
-          RESERVED_PARAMS.include?(param.split("=").first)
+
+        if uri.query
+          params = uri.query.split("&").reject do |param|
+            RESERVED_PARAMS.include?(param.split("=").first)
+          end
+        else
+          params = []
         end
 
         filename = uri.path.sub(%r(^/assets/), "")

--- a/spec/teaspoon/formatter/base_spec.rb
+++ b/spec/teaspoon/formatter/base_spec.rb
@@ -161,8 +161,14 @@ describe Teaspoon::Formatter::Base do
         expect(@log).to eq("\e[31m_message_\e[0m\n\e[36m  # path/file.js?foo=true:42 -- notAnAnonFunc\e[0m\n\n")
       end
 
-      it "doesn't include params if there are none" do
+      it "doesn't include params if there are only the reserved params" do
         formatter.error(mock_result("file.js?body=true&instrument=1"))
+
+        expect(@log).to eq("\e[31m_message_\e[0m\n\e[36m  # path/file.js:42 -- notAnAnonFunc\e[0m\n\n")
+      end
+
+      it "doesn't include params if there are none" do
+        formatter.error(mock_result("file.js"))
 
         expect(@log).to eq("\e[31m_message_\e[0m\n\e[36m  # path/file.js:42 -- notAnAnonFunc\e[0m\n\n")
       end


### PR DESCRIPTION
In my project the body and instrumnet query params were not being added to the file name I believe because we use the already compiled assets to run the tests. Because of this the base formatter were failing because it expects the query parameters to exists.