### PR TITLE
Skip to raise ::DependencyError in phantomjs#run

### DIFF
--- a/lib/teaspoon/driver/phantomjs.rb
+++ b/lib/teaspoon/driver/phantomjs.rb
@@ -34,7 +34,7 @@ module Teaspoon
       def run(*args, &block)
         IO.popen([executable, *args].join(" ")) { |io| io.each(&block) }
 
-        unless $?.success?
+        unless $?.nil? || $?.success?
           raise Teaspoon::DependencyError.new("Failed to use phantomjs, which exited with status code: #{$?.exitstatus}")
         end
       end


### PR DESCRIPTION
if given block returns nil, $?.success will produce
```
  undefined method `success?' for nil:NilClass (NoMethodError)
```

given command:
```
teaspoon -C default
```