### PR TITLE
Rename Registry#equal? to Registry#matches?

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -80,7 +80,7 @@ module Teaspoon
       private
 
       def self.using_phantomjs?
-        Teaspoon::Driver.equal?(Teaspoon.configuration.driver, :phantomjs)
+        Teaspoon::Driver.matches?(Teaspoon.configuration.driver, :phantomjs)
       end
 
       def self.render_exceptions_with_javascript

--- a/lib/teaspoon/registry.rb
+++ b/lib/teaspoon/registry.rb
@@ -26,7 +26,7 @@ module Teaspoon
       driver.call
     end
 
-    def equal?(one, two)
+    def matches?(one, two)
       normalize_name(one) == normalize_name(two)
     end
 

--- a/spec/teaspoon/registry_spec.rb
+++ b/spec/teaspoon/registry_spec.rb
@@ -76,12 +76,12 @@ describe Teaspoon::Registry do
     end
   end
 
-  describe ".equal?" do
-    it "determines if the two conditions are equal after processing" do
-      expect(subject.equal?(:capybara_webkit, :capybara_webkit)).to equal(true)
-      expect(subject.equal?(:capybara_webkit, "capybara-webkit")).to equal(true)
-      expect(subject.equal?("capybara-webkit", :capybara_webkit)).to equal(true)
-      expect(subject.equal?(:capybara_webkit, :phantomjs)).to equal(false)
+  describe ".matches?" do
+    it "determines if the two conditions are matches after processing" do
+      expect(subject.matches?(:capybara_webkit, :capybara_webkit)).to equal(true)
+      expect(subject.matches?(:capybara_webkit, "capybara-webkit")).to equal(true)
+      expect(subject.matches?("capybara-webkit", :capybara_webkit)).to equal(true)
+      expect(subject.matches?(:capybara_webkit, :phantomjs)).to equal(false)
     end
   end
 


### PR DESCRIPTION
This ensures the method doesn't re-define Object#equal? in a way that's
not compatible with the default implementation.

Fixes #448