### PR TITLE
Update engine.rb to work with PRE="1" or 4.2.5.1

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -98,7 +98,7 @@ end
 
 begin
   require 'action_view'
-  if ActionView::VERSION::STRING == '4.2.5'
+  if ActionView::VERSION::STRING.start_with?('4.2.5')
     require 'action_view/helpers/asset_tag_helper'
     module ActionView::Helpers::AssetTagHelper
       def javascript_include_tag(*sources)


### PR DESCRIPTION
A security patch was released as version 4.2.5.1. This fixes the hardcode to support that version, too