### PR TITLE
javascript_include_tag override is also needed for Rails 5

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -98,7 +98,7 @@ end
 
 begin
   require 'action_view'
-  if ActionView::VERSION::STRING.start_with?('4.2.5')
+  if Rails.version >= "4.2.5"
     require 'action_view/helpers/asset_tag_helper'
     module ActionView::Helpers::AssetTagHelper
       def javascript_include_tag(*sources)


### PR DESCRIPTION
We're testing a Rails 5 app using the `rails 5` branch. The only thing that we need to adjust is the Rails version comparison used to check if the `javascript_include_tag` method should be overridden.