### PR TITLE
Use Phantomjs gem if it's defined

### DIFF
--- a/lib/teaspoon/driver/phantomjs.rb
+++ b/lib/teaspoon/driver/phantomjs.rb
@@ -54,8 +54,7 @@ module Teaspoon
 
       def executable
         return @executable if @executable
-        @executable = which("phantomjs")
-        @executable = ::Phantomjs.path if @executable.blank? && defined?(::Phantomjs)
+        @executable = defined?(::Phantomjs) ? ::Phantomjs.path : which("phantomjs")
         return @executable unless @executable.blank?
         raise Teaspoon::MissingDependencyError.new("Unable to locate phantomjs. Install it or use the phantomjs gem.")
       end


### PR DESCRIPTION
If the Phantomjs gem is installed, it should be used first. The first
thing it checks is the equivalent to the `which` function, but with
version checking. It never returns a blank value.