### PR TITLE
Fix the usage of `time` in the junit formatter

### DIFF
--- a/lib/teaspoon/formatter/junit.rb
+++ b/lib/teaspoon/formatter/junit.rb
@@ -9,7 +9,7 @@ module Teaspoon
       def log_runner(result)
         log_line(%{<?xml version="1.0" encoding="UTF-8"?>})
         log_line(%{<testsuites name="Teaspoon">})
-        log_line(%{<testsuite name="#{escape(@suite_name)}" tests="#{@total_count}" time="#{result.start}">})
+        log_line(%{<testsuite name="#{escape(@suite_name)}" tests="#{@total_count}" timestamp="#{result.start.iso8601}">})
       end
 
       def log_suite(result)

--- a/spec/teaspoon/formatter/junit_spec.rb
+++ b/spec/teaspoon/formatter/junit_spec.rb
@@ -11,7 +11,7 @@ describe Teaspoon::Formatter.fetch(:junit) do
   end
 
   describe "#runner" do
-    let(:result) { double(start: "_start_", total: 42) }
+    let(:result) { double(start: Time.current, total: 42) }
 
     before do
       subject.instance_variable_set(:@suite_name, "not_default&")
@@ -19,7 +19,7 @@ describe Teaspoon::Formatter.fetch(:junit) do
 
     it "starts the suite" do
       subject.runner(result)
-      expect(@log).to eq(%{<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="Teaspoon">\n<testsuite name="not_default&amp;" tests="42" time="_start_">\n})
+      expect(@log).to eq(%{<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="Teaspoon">\n<testsuite name="not_default&amp;" tests="42" timestamp="#{result.start.iso8601}">\n})
     end
   end
 


### PR DESCRIPTION
`timestamp` should be used to record when the test ran, `time` is the time taken to execute the tests

https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L195 - `time`
https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L165 - `timestamp`