### PR TITLE
BrowserStack Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Teaspoon
 <img src="https://raw.github.com/modeset/teaspoon/master/screenshots/logo_big.png" alt="Logo by Morgan Keys" align="right" />
 <sup>Logo by [Morgan Keys](http://www.morganrkeys.com/)</sup>
 
-Teaspoon is a Javascript test runner built for Rails. It can run tests in the browser and headless using PhantomJS, Selenium WebDriver, or Capybara Webkit.
+Teaspoon is a Javascript test runner built for Rails. It can run tests in the browser and headless using PhantomJS, Selenium WebDriver, or Capybara Webkit. It can also run your tests on selenium-webgrid providers such as [BrowserStack](https://www.browserstack.com).
 
 Feedback, ideas and pull requests are always welcome, or you can hit us up on Twitter @modeset_.
 
@@ -443,6 +443,16 @@ Some build services also support selenium based setups using Xvfb and Firefox. T
 If you want to generate reports that CI can use you can install Istanbul for coverage reports -- and output the report using the cobertura format, which Hudson and some others can read. You can track spec failure rates by using the tap formatter, or on TeamCity setups you can use the teamcity formatter. A junit formatter is available as well.
 
 We encourage you to experiment and let us know. Feel free to create a wiki article about what you did to get it working on your CI setup.
+
+## Testing on [BrowserStack](https://www.browserstack.com)
+
+Running your javascript tests on BrowserStack infrastructure is easy. The support is available as a `broserstack` driver.
+
+In your `teaspoon_env.rb` file, add `config.driver = :browserstack`. You must add the browsers you need to test on as an array of hash with key `capabilities` in `config.driver_options`. More details with config examples are available [here](https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver)
+
+You can run 10 tests in parallel by default. The number of tests runnning in parallel can be configured by changing `max_parallel` in `config.driver_options`
+
+With these changes, you can run `bundle exec teaspoon` on your command-line and can see your tests running on the [BrowserStack Automate Dashboard](https://browserstack.com/automate).
 
 
 ## Alternative Projects

--- a/lib/generators/teaspoon/install/templates/env_comments.rb.tt
+++ b/lib/generators/teaspoon/install/templates/env_comments.rb.tt
@@ -91,11 +91,12 @@ Teaspoon.configure do |config|
   # Rake:
   # teaspoon DRIVER=phantomjs SERVER_PORT=31337 FAIL_FAST=true FORMATTERS=junit suite=my_suite
 
-  # Specify which headless driver to use. Supports PhantomJS and Selenium Webdriver.
+  # Specify which headless driver to use. Supports PhantomJS, Selenium Webdriver and BrowserStack Webdriver.
   #
   # Available: <%= Teaspoon::Driver.available.keys.map{|f| ":#{f}"}.join(", ") %>
   # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
   # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # BrowserStack Webdriver: https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
   #config.driver = :<%= Teaspoon::Driver.default %>
 
@@ -103,6 +104,7 @@ Teaspoon.configure do |config|
   #
   # PhantomJS: https://github.com/modeset/teaspoon/wiki/Using-PhantomJS
   # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
+  # BrowserStack Webdriver: https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
   #config.driver_options = nil
 

--- a/lib/teaspoon/driver.rb
+++ b/lib/teaspoon/driver.rb
@@ -12,4 +12,5 @@ end
 
 Teaspoon::Driver.register(:phantomjs, "Teaspoon::Driver::Phantomjs", "teaspoon/driver/phantomjs", default: true)
 Teaspoon::Driver.register(:selenium, "Teaspoon::Driver::Selenium", "teaspoon/driver/selenium")
+Teaspoon::Driver.register(:browserstack, "Teaspoon::Driver::BrowserStack", "teaspoon/driver/browserstack")
 Teaspoon::Driver.register(:capybara_webkit, "Teaspoon::Driver::CapybaraWebkit", "teaspoon/driver/capybara_webkit")

--- a/lib/teaspoon/driver/browserstack.rb
+++ b/lib/teaspoon/driver/browserstack.rb
@@ -1,0 +1,114 @@
+# :nocov:
+begin
+  require "selenium-webdriver"
+rescue LoadError
+  Teaspoon.abort("Could not find Selenium Webdriver. Install the selenium-webdriver gem.")
+end
+# :nocov:
+
+require "teaspoon/driver/base"
+
+# The driver creates individual thread for each test.
+# This limit is here to disallow too many threads
+# Override via max_parallel key in options.
+MAX_PARALLEL = 10
+
+# Need to have BrowserStackLocal binary (https://www.browserstack.com/local-testing#command-line)
+# running in the background to use this driver.
+module Teaspoon
+  module Driver
+    class BrowserStack < Base
+      def initialize(options = nil)
+        options ||= {}
+        case options
+        when Hash then @options = options.symbolize_keys
+        when String then @options = JSON.parse(options).symbolize_keys
+        else raise Teaspoon::DriverOptionsError.new(types: "hash or json string")
+        end
+
+        unless @options[:capabilities] && @options[:capabilities].is_a?(Array)
+          raise Teaspoon::DriverOptionsError.new(types: "capabilities array." \
+                                                 "Options must have a key 'capabilities' of type array")
+        end
+        @options[:capabilities].each(&:symbolize_keys!)
+      rescue JSON::ParserError
+        raise Teaspoon::DriverOptionsError.new(types: "hash or json string")
+      end
+
+      def run_specs(runner, url)
+        parallelize do
+          driver = Thread.current[:driver]
+          driver.navigate.to(url)
+          ::Selenium::WebDriver::Wait.new(driver_options).until do
+            done = driver.execute_script("return window.Teaspoon && window.Teaspoon.finished")
+            driver.execute_script("return window.Teaspoon && window.Teaspoon.getMessages() || []").each do |line|
+              runner.process("#{line}\n")
+            end
+            done
+          end
+        end
+      end
+
+      protected
+
+      def parallelize
+        threads = []
+        left_capabilities = capabilities
+        until left_capabilities.empty?
+          left_capabilities.pop(max_parallel).each do |desired_capability|
+            desired_capability[:"browserstack.local"] = true
+            desired_capability[:project] = driver_options[:project] if driver_options[:project]
+            desired_capability[:build] = driver_options[:build] if driver_options[:build]
+            threads << Thread.new do
+              driver = ::Selenium::WebDriver.for(:remote, url: hub_url, desired_capabilities: desired_capability)
+              Thread.current[:driver] = driver
+              capability = driver.capabilities
+
+              Thread.current[:name] = "Session on #{capability[:platform].to_s.strip}," \
+                "#{capability[:browser_name].to_s.strip} #{capability[:version].to_s.strip}"
+
+              yield
+              Thread.current[:driver].quit
+              STDOUT.print("#{Thread.current[:name]} Completed\n") unless Teaspoon.configuration.suppress_log
+            end
+          end
+          threads.each(&:join)
+          threads = []
+        end
+      end
+
+      def capabilities
+        driver_options[:capabilities]
+      end
+
+      def hub_url
+        "https://#{username}:#{access_key}@hub.browserstack.com/wd/hub"
+      end
+
+      def username
+        driver_options[:username] || ENV["BROWSERSTACK_USERNAME"]
+      end
+
+      def access_key
+        driver_options[:access_key] || ENV["BROWSERSTACK_ACCESS_KEY"]
+      end
+
+      def max_parallel
+        parallel = MAX_PARALLEL
+        begin
+          parallel = driver_options[:max_parallel].to_i if driver_options[:max_parallel].to_i > 0
+        rescue
+        end
+        parallel
+      end
+
+      def driver_options
+        @driver_options ||= HashWithIndifferentAccess.new(
+          timeout: Teaspoon.configuration.driver_timeout.to_i,
+          interval: 0.01,
+          message: "Timed out"
+        ).merge(@options)
+      end
+    end
+  end
+end

--- a/spec/teaspoon/command_line_spec.rb
+++ b/spec/teaspoon/command_line_spec.rb
@@ -59,6 +59,7 @@ describe Teaspoon::CommandLine do
           -d, --driver DRIVER              Specify driver:
                                              phantomjs (default)
                                              selenium
+                                             browserstack
                                              capybara_webkit
               --driver-options OPTIONS     Specify driver-specific options to pass into the driver.
                                              e.g. "--ssl-protocol=any --ssl-certificates-path=/path/to/certs".

--- a/spec/teaspoon/driver/browserstack_spec.rb
+++ b/spec/teaspoon/driver/browserstack_spec.rb
@@ -1,0 +1,123 @@
+require "spec_helper"
+
+describe Teaspoon::Driver.fetch(:browserstack) do
+  let(:runner) { double }
+  let(:wait) { double(until: nil) }
+  let(:driver) { double(quit: nil, navigate: @navigate = double(to: nil), execute_script: nil, capabilities: {}) }
+
+  before do
+    allow(Selenium::WebDriver).to receive(:for).and_return(driver)
+    allow(Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+  end
+
+  describe "#initialize" do
+    it "assigns @options" do
+      subject = described_class.new(capabilities: [{ foo: "bar" }])
+      expect(subject.instance_variable_get(:@options)).to eq(capabilities: [{ foo: "bar" }])
+    end
+
+    it "raises an exception if options does not have a capabilities array" do
+      expect { described_class.new('{"foo":"bar"}') }.to raise_error(
+        Teaspoon::DriverOptionsError,
+        "Malformed driver options: expected a valid capabilities array." \
+        "Options must have a key 'capabilities' of type array."
+      )
+    end
+
+    it "accepts a string for options" do
+      subject = described_class.new('{"capabilities":[{"foo":"bar"}]}')
+      expect(subject.instance_variable_get(:@options)).to eq(capabilities: [{ foo: "bar" }])
+    end
+
+    it "converts all the keys in each hash in capabilities array to symbols" do
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }, { "foo2" => "bar2" }])
+      expect(subject.instance_variable_get(:@options)).to eq(capabilities: [{ foo: "bar" }, { foo2: "bar2" }])
+    end
+
+    it "raises an exception if the options aren't understood" do
+      expect { described_class.new(true) }.to raise_error(
+        Teaspoon::DriverOptionsError,
+        "Malformed driver options: expected a valid hash or json string."
+      )
+    end
+
+    it "raises an exception if the options aren't parseable" do
+      expect { described_class.new("{foo:bar}") }.to raise_error(
+        Teaspoon::DriverOptionsError,
+        "Malformed driver options: expected a valid hash or json string."
+      )
+    end
+  end
+
+  describe "#run_specs" do
+    it "appends 'browserstack.local = true to all capabilities" do
+      expect(Selenium::WebDriver).to receive(:for).with(
+        :remote,
+        url: "https://dummy_user:dummy_key@hub.browserstack.com/wd/hub",
+        desired_capabilities: { foo: "bar", "browserstack.local" => true }
+      )
+      expect(Selenium::WebDriver).to receive(:for).with(
+        :remote,
+        url: "https://dummy_user:dummy_key@hub.browserstack.com/wd/hub",
+        desired_capabilities: { foo2: "bar2", "browserstack.local" => true }
+      )
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }, { "foo2" => "bar2" }],
+                                    username: "dummy_user", access_key: "dummy_key")
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "accepts BrowserStack username and accesskey from options" do
+      expect(Selenium::WebDriver).to receive(:for).with(
+        :remote,
+        url: "https://dummy_user:dummy_key@hub.browserstack.com/wd/hub",
+        desired_capabilities: { foo: "bar", "browserstack.local" => true }
+      )
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }],
+                                    username: "dummy_user", access_key: "dummy_key")
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "accepts BrowserStack username and accesskey from environment" do
+      allow(ENV).to receive(:[]).with("BROWSERSTACK_USERNAME").and_return("env_dummy_user")
+      allow(ENV).to receive(:[]).with("BROWSERSTACK_ACCESS_KEY").and_return("env_dummy_key")
+
+      expect(Selenium::WebDriver).to receive(:for).with(
+        :remote,
+        url: "https://env_dummy_user:env_dummy_key@hub.browserstack.com/wd/hub",
+        desired_capabilities: { foo: "bar", "browserstack.local" => true })
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }])
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "navigates to the correct url" do
+      expect(@navigate).to receive(:to).with("_url_")
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }])
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "ensures quit is called on the driver for every browser" do
+      expect(driver).to receive(:quit).twice
+      subject = described_class.new(capabilities: [{"foo" => "bar"}, {"foo2" => "bar2"}])
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "waits for the specs to complete, setting the interval, timeout and message" do
+      hash = HashWithIndifferentAccess.new(timeout: 180, interval: 0.01, message: "Timed out", capabilities: anything)
+      expect(Selenium::WebDriver::Wait).to receive(:new).with(hash)
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }])
+      subject.run_specs(runner, "_url_")
+    end
+
+    it "waits until it's done (checking Teaspoon.finished) and processes each line" do
+      expect(wait).to receive(:until) { |&b| @block = b }
+      expect(driver).to receive(:execute_script).with("return window.Teaspoon && window.Teaspoon.finished").
+        and_return(true)
+      expect(driver).to receive(:execute_script).with("return window.Teaspoon && window.Teaspoon.getMessages() || []").
+        and_return(["_line_"])
+      expect(runner).to receive(:process).with("_line_\n")
+      subject = described_class.new(capabilities: [{ "foo" => "bar" }])
+      subject.run_specs(runner, "_url_")
+      @block.call
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a 'browserstack' driver which can be used to run tests on browserstack.

Additional support in spec/teaspoon_env.rb : 
```ruby
config.driver = :browserstack
config.driver_options = {
  capabilities: [{
    os: "OS X",
    os_version: "El Capitan",
    browser: "chrome",
    browser_version: ""
  }, {
    os: "Windows",
    os_version: "10",
    browser: "firefox",
    browser_version: "44"
  }],
  username: ENV['BROWSERSTACK_USERNAME'],
  access_key: ENV['BROWSERSTACK_ACCESS_KEY'],
  project: 'BrowserStack Project Name'
  build: 'BrowserStack Build Name',
}
```
The capabilities object is send as is to BrowserStack as desired_capabilities.

To access locally served pages on BrowserStack, we need to run a [platform specific binary](https://www.browserstack.com/local-testing#command-line) in the background. So, will have to run the binary from the command-line before running tests.