### PR TITLE
Fix: Asset was not declared to be precompiled in production.

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -98,7 +98,7 @@ end
 
 begin
   require 'action_view'
-  if ActionView::VERSION::STRING.start_with?('4.2.5')
+  if ActionView::VERSION::STRING >= '4.2.5'
     require 'action_view/helpers/asset_tag_helper'
     module ActionView::Helpers::AssetTagHelper
       def javascript_include_tag(*sources)


### PR DESCRIPTION
See https://github.com/modeset/teaspoon/issues/460.
The condition needs to cover Rails 4.2.6 and future versions.