### PR TITLE
Fix support for Sprockets 4

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -51,6 +51,9 @@ module Teaspoon
 
     def self.inject_instrumentation
       Sprockets::Environment.send(:include, Teaspoon::SprocketsInstrumentation)
+      Sprockets::CachedEnvironment.send(:include, Teaspoon::SprocketsInstrumentation)
+    rescue NameError
+      # Handle cached environment in Sprockets 2.x
       Sprockets::Index.send(:include, Teaspoon::SprocketsInstrumentation)
     end
 


### PR DESCRIPTION
``Sprockets::Index`` was a reference to the cached environment in Sprockets 2, deprecated in Sprockets 3, and removed in Sprockets 4.