### PR TITLE
#470: providing option to use placeholders in output file for formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,20 @@ config.suite :my_suite do |suite|
 end
 ```
 
+When defining multiple suites and running the tests on a CI (like Jenkins), you might need the output of `bundle exec teaspoon` in your XML-reports.
+To get one XML-file per suite you are running, you might want to add e.g a `junit` formatter which creates one result file per suite. 
+ 
+```ruby
+config.formatters = ["junit>#{Rails.root.join(["spec", "reports", "teaspoon_%{suite_name}.xml"])}"]
+``` 
+
+Will create a single file for each defined test-suite under `spec/reports/teasoon_%{suite_name}.xml`. 
+Allowed placeholders are:
+
+- `suite_name`: the name defined by your config (`config.suite :my_suite ...`)
+- `date`: the execution timestamp of your test (`Date.now.to_i`)
+
+
 ### Hooks
 
 Hooks are designed to facilitate loading fixtures or other things that might be required on the back end before, after, or during running a suite or test.

--- a/lib/teaspoon/formatter/base.rb
+++ b/lib/teaspoon/formatter/base.rb
@@ -7,7 +7,7 @@ module Teaspoon
 
       def initialize(suite_name = :default, output_file = nil)
         @suite_name  = suite_name.to_s
-        @output_file = output_file
+        @output_file = parse_output_file(output_file)
         @stdout      = ""
         @suite       = nil
         @last_suite  = nil
@@ -153,6 +153,24 @@ module Teaspoon
         filename = uri.path.sub(%r(^/assets/), "")
         filename += "?#{params.join("&")}" if params.any?
         filename
+      end
+
+      def parse_output_file(output)
+        return output unless output
+        output.gsub(/%{([^}]*)}/) { parse_output_capture($1) }
+      end
+
+      def parse_output_capture(cap)
+        case cap
+        when "suite_name"
+          @suite_name
+        when "date"
+          Time.now.to_i
+        else
+          warn ["Teaspoon::Formatter - Output File can only contain the placeholders %{suite_name} or %{date}.",
+                "%{#{cap}} is not supported and will be ignored."].join("\n")
+          ""
+        end
       end
     end
   end


### PR DESCRIPTION
When defining multiple suites and running the tests on a CI (like Jenkins), you might need the output of `bundle exec teaspoon` in your XML-reports.
To get one XML-file per suite you are running, you might want to add e.g a `junit` formatter which creates one result file per suite. 
 
```ruby
config.formatters = ["junit>#{Rails.root.join(["spec", "reports", "teaspoon_%{suite_name}.xml"])}"]
``` 

Will create a single file for each defined test-suite under `spec/reports/teasoon_%{suite_name}.xml`. 
Allowed placeholders are:

- `suite_name`: the name defined by your config (`config.suite :my_suite ...`)
- `date`: the execution timestamp of your test (`Date.now.to_i`)