### PR TITLE
Add support for Sprockets 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
 gem "rails", "5.0.0.beta3"
+gem "sprockets", "4.0.0.beta2"
+gem "sass-rails", "6.0.0.beta1"
 gemspec name: "teaspoon"
 
 group :development, :test do

--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -119,3 +119,14 @@ begin
   end
 rescue
 end
+
+# Some Sprockets patches to work with Sprockets 2.x
+unless Sprockets::Asset.public_method_defined?(:filename)
+  module Sprockets
+    class Asset
+      def filename
+        pathname.to_s
+      end
+    end
+  end
+end

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -45,14 +45,14 @@ module Teaspoon
 
     def self.ignored?(asset)
       Array(Teaspoon::Coverage.configuration.ignore).any? do |ignore|
-        asset.pathname.to_s.match(ignore)
+        asset.filename.match(ignore)
       end
     rescue Teaspoon::UnknownCoverage
       false
     end
 
     def add_instrumentation(asset)
-      source_path = asset.pathname.to_s
+      source_path = asset.filename
       Dir.mktmpdir do |temp_path|
         input_path = File.join(temp_path, File.basename(source_path)).sub(/\.js.+/, ".js")
         File.open(input_path, "w") { |f| f.write(asset.source) }

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -53,8 +53,7 @@ module Teaspoon
         asset = @env.find_asset(source)
 
         if asset && asset.respond_to?(:logical_path)
-          assets = config.expand_assets ? asset.to_a : [asset]
-          assets.map { |a| asset_url(a) }
+          asset_and_dependencies(asset).map { |a| asset_url(a) }
         else
           source.blank? ? [] : [source]
         end
@@ -64,10 +63,22 @@ module Teaspoon
     def asset_url(asset)
       params = []
       params << "body=1" if config.expand_assets
-      params << "instrument=1" if instrument_file?(asset.pathname.to_s)
+      params << "instrument=1" if instrument_file?(asset.filename)
       url = asset.logical_path
       url += "?#{params.join("&")}" if params.any?
       url
+    end
+
+    def asset_and_dependencies(asset)
+      if config.expand_assets
+        if asset.respond_to?(:to_a)
+          asset.to_a
+        else
+          asset.metadata[:included].map { |uri| @env.load(uri) }
+        end
+      else
+        [asset]
+      end
     end
 
     def instrument_file?(file)

--- a/spec/javascripts/spec_helper.coffee
+++ b/spec/javascripts/spec_helper.coffee
@@ -1,8 +1,0 @@
-#= require support/json2
-#= require jquery
-
-window.passing = true
-window.failing = false
-
-# create the log method on console in case it doesn't exist -- several tests rely on it being spied upon
-window.console = {log: ->} unless window.console

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,0 +1,11 @@
+//= require support/json2
+//= require jquery
+
+window.passing = true;
+window.failing = false;
+
+// create the log method on console in case it doesn't exist -- several tests
+// rely on it being spied upon
+if (!window.console) {
+  window.console = {log: function() {}};
+}

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -6,7 +6,7 @@ require "rack/test"
 describe Teaspoon::Instrumentation do
   subject { described_class }
 
-  let(:asset) { double(source: source, pathname: "path/to/instrument.js") }
+  let(:asset) { double(source: source, filename: "path/to/instrument.js") }
   let(:source) { "function add(a, b) { return a + b } // ☃ " }
   let(:response) { [200, { "Content-Type" => "application/javascript" }, asset] }
   let(:env) { { "QUERY_STRING" => "instrument=true" } }
@@ -120,7 +120,7 @@ describe Teaspoon::Instrumentation do
   end
 
   describe "integration" do
-    let(:asset) { Rails.application.assets.find_asset("support/instrumented.coffee") }
+    let(:asset) { Rails.application.assets.find_asset("support/instrumented", accept: "application/javascript") }
 
     it "instruments a file" do
       pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.executable


### PR DESCRIPTION
[Fix support for Sprockets 4](https://github.com/modeset/teaspoon/pull/468) ensured that Teaspoon successfully loaded with Sprockets 4. This finishes up the job to ensure Teaspoon works with Sprockets 4.