### PR TITLE
Suite controller now returns correct status codes, and updated js to …

### DIFF
--- a/app/assets/javascripts/teaspoon/hook.coffee
+++ b/app/assets/javascripts/teaspoon/hook.coffee
@@ -19,4 +19,4 @@ Teaspoon.hook = (name, payload = {}) ->
 
   xhrRequest "#{Teaspoon.suites.active}/#{name}", payload, ->
     return unless xhr.readyState == 4
-    throw("Unable to call hook \"#{url}\".") unless xhr.status == 200
+    throw JSON.parse(xhr.response).err

--- a/app/controllers/teaspoon/suite_controller.rb
+++ b/app/controllers/teaspoon/suite_controller.rb
@@ -18,8 +18,13 @@ class Teaspoon::SuiteController < ActionController::Base
 
   def hook
     hooks = Teaspoon::Suite.new(params).hooks[params[:hook].to_s]
-    hooks.each { |hook| hook.call(hook_params(params[:args])) }
-    head(:success)
+
+    if hooks.present?
+      hooks.each { |hook| hook.call(hook_params(params[:args])) }
+      head(:ok)
+    else
+      render status: :not_found, json: {err: "The `#{params[:hook].to_s}` hook is not defined in the `#{params[:suite].to_s}` suite "}
+    end
   end
 
   def fixtures

--- a/app/controllers/teaspoon/suite_controller.rb
+++ b/app/controllers/teaspoon/suite_controller.rb
@@ -23,7 +23,7 @@ class Teaspoon::SuiteController < ActionController::Base
       hooks.each { |hook| hook.call(hook_params(params[:args])) }
       head(:ok)
     else
-      render status: :not_found, json: {err: "The `#{params[:hook].to_s}` hook is not defined in the `#{params[:suite].to_s}` suite "}
+      render status: :not_found, json: { err: "The `#{params[:hook]}` hook is not defined in the `#{params[:suite]}` suite " }
     end
   end
 

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine1.js
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine1.js
@@ -472,8 +472,8 @@
       if (xhr.readyState !== 4) {
         return;
       }
-      if (xhr.status !== 200) {
-        throw "Unable to call hook \"" + url + "\".";
+      if (xhr.status !== 200 && xhr.status !== 500) {
+        throw JSON.parse(xhr.response).err;
       }
     });
   };

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine2.js
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine2.js
@@ -473,7 +473,7 @@
         return;
       }
       if (xhr.status !== 200) {
-        throw "Unable to call hook \"" + url + "\".";
+        throw JSON.parse(xhr.response).err;
       }
     });
   };

--- a/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon-mocha.js
+++ b/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon-mocha.js
@@ -473,7 +473,7 @@
         return;
       }
       if (xhr.status !== 200) {
-        throw "Unable to call hook \"" + url + "\".";
+        throw JSON.parse(xhr.response).err;
       }
     });
   };

--- a/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon-qunit.js
+++ b/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon-qunit.js
@@ -473,7 +473,7 @@
         return;
       }
       if (xhr.status !== 200) {
-        throw "Unable to call hook \"" + url + "\".";
+        throw JSON.parse(xhr.response).err;
       }
     });
   };


### PR DESCRIPTION
…handle hook status codes.

Fixes #493 

 - [x] Fix `SuitesController` so it doesn't always return a 500 status
 - [x] `SuitesController` should return a 200 on success, and a 404 when the hook can't be found.
 - [x] All hook xhr javascript should throw the error returned by the server